### PR TITLE
Generics and Lra support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,21 @@ description = "A platform agnostic driver for the drv2605 haptic driver"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/wez/drv2605"
+edition = "2018"
 
 [dependencies]
 embedded-hal = "~0.2"
 bitfield = "~0.13"
 
+
 [dev-dependencies]
-metro_m0 = { version="0.1.0", path = "../atsamd21-rs/metro_m0" }
-cortex-m = "~0.5"
-panic_rtt = "~0.1"
-cortex-m-rt = "~0.5"
+metro_m0 = "0.2.0"
+cortex-m = "~0.6"
+panic_rtt = "~0.2"
 jlink_rtt = "~0.1"
+
+[dev-dependencies.cortex-m-rt]
+version = "~0.6"
 
 [features]
 use_semihosting = []

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Drv2605, Drv2605Erm, Effect};
+use drv2605::{Drv2605, Drv2605Erm, HapticBuilder};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -49,14 +49,12 @@ fn main() -> ! {
         &mut pins.port,
     );
 
-    let mut haptic = Drv2605::<_, Drv2605Erm>::new(i2c);
     dbgprint!("about to init device");
 
-    haptic.config().unwrap();
-    haptic.set_open_loop().unwrap();
-    haptic.set_library(drv2605::LibrarySelection::B).unwrap();
-    haptic
-        .set_single_effect(Effect::TransitionRampDownLongSmoothOne100to0)
+    let mut haptic: Drv2605<_, Drv2605Erm> = HapticBuilder::new(0x3E, 0x89, 19)
+        .load_calibration(0x09, 0x79, 1) //or .otp() or nothing for auto_calibration()
+        // .set_open_loop()
+        .connect(i2c)
         .unwrap();
 
     loop {

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
     let mut haptic = Drv2605l::new(i2c, Calibration::Auto(calib), false).unwrap();
 
     // Or lra autocalibration would look like this.
-    // let calib = CalibrationParams::default();
+    // let mut calib = CalibrationParams::default();
     // these are tricky and are computed from the lra motor and drv2605l datasheets
     // calib.rated = 0x3E;
     // calib.clamp = 0x8C;

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -57,6 +57,9 @@ fn main() -> ! {
     //     twi,
     //     LraCalibration::Auto(
     //         GeneralParams::default(),
+    //        // these are settings taken from the drv2605 evm for the SEMCO1030 (Mplus)
+    //        // 205hz freq, nominal voltage 1.5V, max voltage 3.0V, DRV2605_LRA_SAMPLE_TIME: 3, DRV2605_LRA_BLANKING_TIME: 2, DRV2605_LRA_IDISS_TIME: 2
+    //        // REQUIRED, you need to change based on your motor
     //         LraParams {
     //             rated: 0x3E,
     //             clamp: 0x89,

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     //             drive_time: 19,
     //         },
     //     ),
-    // );
+    // ).unwrap();
 
     // let params = haptic.calibration().unwrap();
     // info!(
@@ -112,7 +112,7 @@ fn main() -> ! {
             red_led.set_low();
         }
 
-        dbgprint!("go: {:?}", haptic.set_go(true));
+        dbgprint!("go: {:?}", haptic.set_go());
     }
 
     // or rtp mode would look like this instead

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Drv2605, Effect};
+use drv2605::{Drv2605, Drv2605Erm, Effect};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -49,14 +49,15 @@ fn main() -> ! {
         &mut pins.port,
     );
 
-    let mut haptic = Drv2605::new(i2c);
+    let mut haptic = Drv2605::<_, Drv2605Erm>::new(i2c);
     dbgprint!("about to init device");
-    dbgprint!("init say: {:?}", haptic.init_open_loop_erm());
 
-    dbgprint!(
-        "set effect: {:?}",
-        haptic.set_single_effect(Effect::TransitionRampDownLongSmoothOne100to0)
-    );
+    haptic.config().unwrap();
+    haptic.set_open_loop().unwrap();
+    haptic.set_library(drv2605::LibrarySelection::B).unwrap();
+    haptic
+        .set_single_effect(Effect::TransitionRampDownLongSmoothOne100to0)
+        .unwrap();
 
     loop {
         for _ in 0..10 {

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -3,23 +3,17 @@
 // to build for the metro_m0
 #![no_std]
 #![no_main]
-#![feature(used)]
 
-extern crate cortex_m;
-extern crate jlink_rtt;
 extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
-#[macro_use(entry)]
-extern crate cortex_m_rt;
-
-extern crate drv2605;
+use cortex_m_rt::entry;
 use drv2605::{Drv2605, Effect};
-
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
 use hal::{CorePeripherals, Peripherals};
+use jlink_rtt;
 
 macro_rules! dbgprint {
     ($($arg:tt)*) => {
@@ -31,8 +25,7 @@ macro_rules! dbgprint {
     };
 }
 
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -92,16 +92,16 @@ fn main() -> ! {
     haptic
         .set_rom_single(Effect::TransitionRampDownLongSmoothOne100to0)
         .unwrap();
-    // or you could set several
+    // or you could set a sequence of up to 8 Effects including delays
     // let roms = [
     //     Effect::StrongClick100,
-    //     Effect::BuzzOne100,
+    //     Effect::Delays(10),
     //     Effect::StrongClick100,
-    //     Effect::BuzzOne100,
+    //     Effect::Delays(100),
     //     Effect::StrongClick100,
-    //     Effect::BuzzOne100,
-    //     Effect::TransitionRampDownLongSmoothOne100to0,
-    //     Effect::None, //stop early
+    //     Effect::Stop, //stop early
+    //     Effect::Stop, //stop early
+    //     Effect::Stop, //stop early
     // ];
     // haptic.set_rom(&roms).unwrap();
 

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library, Mode, RomOptions};
+use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library, Mode, RomParams};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -57,16 +57,18 @@ fn main() -> ! {
     // Or lra autocalibration would look like this.
     // let mut calib = CalibrationParams::default();
     // these are tricky and are computed from the lra motor and drv2605l datasheets
-    // calib.rated = 0x3E;
-    // calib.clamp = 0x8C;
+    // calib.rated_voltage = 0x3E;
+    // calib.overdrive_voltage_clamp = 0x8C;
     // calib.drive_time = 0x13;
     // let mut haptic = Drv2605l::new(i2c, Calibration::Auto(calib), false).unwrap();
 
     // print the sucessful calibration values so you can hardcode them
     // let params = haptic.calibration().unwrap();
-    // info!(
-    //     "comp:{} bemf:{} gain:{}",
-    //     params.comp, params.bemf, params.gain
+    // dbgprint!(
+    //     "compenstation:{} back_emf:{} back_emf_gain:{}",
+    //     params.compenstation,
+    //     params.back_emf,
+    //     params.back_emf_gain
     // );
 
     // and hardcode them instead of using calibration like this
@@ -74,20 +76,20 @@ fn main() -> ! {
     //     i2c,
     //     //from the
     //     Calibration::Load(drv2605::LoadParams {
-    //         comp: 0x3E,
-    //         bemf: 0x89,
-    //         gain: 0x25,
+    //         compenstation: 0x3E,
+    //         back_emf: 0x89,
+    //         back_emf_gain: 0x25,
     //     }),
     //     false,
     // )
     // .unwrap();
-    dbgprint!("device successfully init");
+    // dbgprint!("device successfully init");
 
     // rom mode using built in effects. Each library has all the same
     // vibrations, but is tuned to work for certain motor characteristics so its
     // important to choose Library for for your motor characteristics
     haptic
-        .set_mode(Mode::Rom(Library::B, RomOptions::default()))
+        .set_mode(Mode::Rom(Library::B, RomParams::default()))
         .unwrap();
 
     // set one effect to happen when go bit enabled

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library, Mode};
+use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library, Mode, RomOptions};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -86,7 +86,9 @@ fn main() -> ! {
     // rom mode using built in effects. Each library has all the same
     // vibrations, but is tuned to work for certain motor characteristics so its
     // important to choose Library for for your motor characteristics
-    haptic.set_mode(Mode::Rom(Library::B)).unwrap();
+    haptic
+        .set_mode(Mode::Rom(Library::B, RomOptions::default()))
+        .unwrap();
 
     // set one effect to happen when go bit enabled
     haptic

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Drv2605l, Effect, ErmCalibration, ErmLibrary, LoadParams};
+use drv2605::{Drv2605l, Effect, ErmCalibration, Library, LoadParams};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -84,7 +84,7 @@ fn main() -> ! {
 
     // rom mode using built in effects, choose the correct ErmLibrary for your
     // motor characteristics
-    haptic.set_mode_rom(ErmLibrary::B).unwrap();
+    haptic.set_mode_rom(Library::B).unwrap();
 
     // set one effect to happen when go bit enabled
     haptic

--- a/examples/metro.rs
+++ b/examples/metro.rs
@@ -8,7 +8,7 @@ extern crate metro_m0 as hal;
 extern crate panic_rtt;
 
 use cortex_m_rt::entry;
-use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library};
+use drv2605::{Calibration, CalibrationParams, Drv2605l, Effect, Library, Mode};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -86,7 +86,7 @@ fn main() -> ! {
     // rom mode using built in effects. Each library has all the same
     // vibrations, but is tuned to work for certain motor characteristics so its
     // important to choose Library for for your motor characteristics
-    haptic.set_mode_rom(Library::B).unwrap();
+    haptic.set_mode(Mode::Rom(Library::B)).unwrap();
 
     // set one effect to happen when go bit enabled
     haptic
@@ -119,7 +119,7 @@ fn main() -> ! {
 
     // or rtp mode would look like this instead
     // haptic.set_standby(false).unwrap();
-    // haptic.set_mode_rtp().unwrap();
+    // haptic.set_mode(Mode::RealTimePlayback).unwrap();
     // loop {
     //     haptic.set_standby(false).unwrap();
 
@@ -140,6 +140,6 @@ fn main() -> ! {
 
     // or pwm mode, assuming pwm has previously been configured and is
     // outputting to the in/trig pin
-    // haptic.set_mode_pwm().unwrap();
+    // haptic.set_mode(Mode::Pwm).unwrap();
     // haptic.set_standby(false).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ where
     /// Returns a calibrated Drv2605l device configured to standby mode for
     /// power savings. Use a `set_mode` and `set_go` to trigger a vibration.
     pub fn new(i2c: I2C, calibration: Calibration, lra: bool) -> Result<Self, DrvError> {
-        let mut haptic = Self { i2c, lra: false };
+        let mut haptic = Self { i2c, lra };
         haptic.check_id(7)?;
 
         // todo reset so registers are defaulted. Timing out..  need a solution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@ A platform agnostic Rust friver for the drv2605, based on the
 [`embedded-hal`] traits.
 */
 #![no_std]
-extern crate embedded_hal as hal;
-#[macro_use]
-extern crate bitfield;
 
-use hal::blocking::i2c::{Write, WriteRead};
+use bitfield::bitfield;
+use embedded_hal::blocking::i2c::{Write, WriteRead};
 
-bitfield!{
+bitfield! {
     pub struct StatusReg(u8);
     impl Debug;
     /// Latching overcurrent detection flag.  If the load impedance is below
@@ -100,7 +98,7 @@ impl From<u8> for Mode {
     }
 }
 
-bitfield!{
+bitfield! {
     pub struct ModeReg(u8);
     impl Debug;
     /// Device reset. Setting this bit performs the equivalent operation of power
@@ -146,7 +144,7 @@ impl From<u8> for LibrarySelection {
     }
 }
 
-bitfield!{
+bitfield! {
     pub struct RegisterThree(u8);
     impl Debug;
     /// This bit sets the output driver into a true high-impedance state. The device
@@ -413,7 +411,7 @@ pub enum Effect {
     SmoothHumFive10 = 123,
 }
 
-bitfield!{
+bitfield! {
     pub struct WaveformReg(u8);
     impl Debug;
     /// When this bit is set, the WAV_FRM_SEQ[6:0] bit is interpreted as a wait
@@ -463,7 +461,7 @@ impl WaveformReg {
     }
 }
 
-bitfield!{
+bitfield! {
     pub struct GoReg(u8);
     impl Debug;
     /// This bit is used to fire processes in the DRV2605 device. The process
@@ -479,7 +477,7 @@ bitfield!{
     pub go, set_go: 0;
 }
 
-bitfield!{
+bitfield! {
     pub struct FeedbackControlReg(u8);
     impl Debug;
 
@@ -534,7 +532,7 @@ bitfield!{
     pub bemf_gain, set_bemf_gain: 1, 0;
 }
 
-bitfield!{
+bitfield! {
     pub struct Control1Reg(u8);
     impl Debug;
     /// This bit applies higher loop gain during overdrive to enhance actuator transient response.
@@ -558,7 +556,7 @@ bitfield!{
     pub drive_time, set_drive_time: 4, 0;
 }
 
-bitfield!{
+bitfield! {
     pub struct Control2Reg(u8);
     impl Debug;
     /// The BIDIR_INPUT bit selects how the engine interprets data.
@@ -606,7 +604,7 @@ bitfield!{
     pub idiss_time, set_idiss_time: 1, 0;
 }
 
-bitfield!{
+bitfield! {
     pub struct Control3Reg(u8);
     impl Debug;
 
@@ -660,7 +658,7 @@ bitfield!{
     pub lra_open_loop, set_lra_open_loop: 0;
 }
 
-bitfield!{
+bitfield! {
     pub struct Control4Reg(u8);
     impl Debug;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub enum DrvError {
 /// same waveform
 const ADDRESS: u8 = 0x5a;
 
-// Choose calibration method during driver construction
+/// Choose calibration method during driver construction
 pub enum Calibration {
     /// Many calibration params can be defaulted, and maybe the entire thing for
     /// some ERM motors. Required params for LRA motors especially though should
@@ -368,16 +368,16 @@ pub enum Calibration {
     /// motor to some kind of mass. It can't calibrate if its jumping around on
     /// a board or a desk.
     Auto(CalibrationParams),
-    // Load previously calibrated values. It is common to do an autocalibration
-    // and then read back the calibration parameters so you can hardcode them
+    /// Load previously calibrated values. It is common to do an autocalibration
+    /// and then read back the calibration parameters so you can hardcode them
     Load(LoadParams),
-    // Values were previously programmed into nonvolatile memory. This is not common.
+    /// Values were previously programmed into nonvolatile memory. This is not common.
     Otp,
 }
 
-// Computed calibration parameters. Provide previously calculated parameters
-// during construction, or after read back the calibrated values for hardcoding
-// after succsesfully Auto calibration.s
+/// Computed calibration parameters. Provide previously calculated parameters
+/// during construction, or after read back the calibrated values for hardcoding
+/// after succsesfully Auto calibration.s
 pub struct LoadParams {
     /// Automatic Compensation for Resistive Losses
     pub comp: u8,
@@ -431,6 +431,8 @@ impl Default for CalibrationParams {
     }
 }
 
+/// The purpose of the functionality is to add time stretching (or time
+/// shrinking) to the waveform. Defaults are totally fine.
 #[derive(Debug, Clone, Copy)]
 pub struct RomOptions {
     /// Overdrive Time Offset (ms) = overdrive_time * playback_interval

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ where
 
                 feedback.set_fb_brake_factor(c.brake_factor);
                 feedback.set_loop_gain(c.loop_gain);
+                feedback.set_n_erm_lra(true);
                 ctrl2.set_sample_time(c.lra_sample_time);
                 ctrl2.set_blanking_time(c.lra_blanking_time);
                 ctrl2.set_idiss_time(c.lra_idiss_time);
@@ -505,8 +506,22 @@ pub struct GeneralParams {
 
 /// additional fields requited for LRA calibration
 pub struct LraParams {
+    // 8.5.2.1 Rated Voltage Programming
     pub rated: u8,
+    // 8.5.2.2 Overdrive Voltage-Clamp Programming
+    /// Note the LRA and ERM equation labels are swapped
+    /// confirmed https://e2e.ti.com/support/other_analog/haptics/f/927/t/655886
+    /// (21.64x10-3 x OD_CLAMP[7:0] x (tDRIVE_TIME - 300x10^-6)) / (tDRIVE_TIME
+    /// + tIDISS_TIME + tBLANKING_TIME)
     pub clamp: u8,
+    // 8.5.1.1 Drive-Time Programming
+    // Sets initial guess for LRA drive-time in LRA mode
+    // Optimum drive time in ms is half LRA Period
+    // drive time ms = drive_time * 0.1 ms + 0.5 ms
+    // drive_time = (2.5ms-.5)/(.1 * drive time ms)
+    // For example if the motor resonance frequency is 200 Hz, period is 1/200hz is .005 or 5ms. 5ms/2 =2.5ms
+    // drive_time = (2.5ms-.5ms)/(.1 * 2.5ms)
+    // drive_time = 2/.25=8
     pub drive_time: u8,
 }
 
@@ -517,10 +532,10 @@ impl Default for GeneralParams {
             brake_factor: 2,
             loop_gain: 2,
             lra_sample_time: 3,
-            lra_blanking_time: 1, //not on drv2605
-            lra_idiss_time: 1,    //not on drv2605
+            lra_blanking_time: 1,
+            lra_idiss_time: 1,
             auto_cal_time: 3,
-            lra_zc_det_time: 0, //not on drv2605
+            lra_zc_det_time: 0,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,9 @@ where
     }
 
     /// Trigger a GO for whatever mode is enabled
-    pub fn set_go(&mut self, go: bool) -> Result<(), DrvError> {
+    pub fn set_go(&mut self) -> Result<(), DrvError> {
         let mut register = GoReg(self.read(Register::Go)?);
-        register.set_go(go);
+        register.set_go(true);
         self.write(Register::Go, register.0)
     }
 
@@ -402,7 +402,7 @@ where
         mode.set_mode(Mode::Diagnostics as u8);
         self.write(Register::Mode, mode.0)?;
 
-        self.set_go(true)?;
+        self.set_go()?;
 
         //todo timeout
         while GoReg(self.read(Register::Go)?).go() {}
@@ -423,7 +423,7 @@ where
         mode.set_mode(Mode::AutoCalibration as u8);
         self.write(Register::Mode, mode.0)?;
 
-        self.set_go(true)?;
+        self.set_go()?;
 
         //todo timeout
         while GoReg(self.read(Register::Go)?).go() {}
@@ -460,7 +460,6 @@ pub enum DrvError {
 /// same waveform
 pub const ADDRESS: u8 = 0x5a;
 
-#[allow(unused)]
 pub enum LraCalibration {
     Otp,
     /// When using autocalibration be sure to secure the motor to mass. It can't
@@ -469,7 +468,6 @@ pub enum LraCalibration {
     Load(LoadParams),
 }
 
-#[allow(unused)]
 pub enum ErmCalibration {
     Otp,
     /// When using autocalibration be sure to secure the motor to mass. It can't

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod registers;
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 pub use registers::{
     Control1Reg, Control2Reg, Control3Reg, Control4Reg, Effect, FeedbackControlReg, GoReg, Library,
-    LibrarySelectionReg, ModeReg, Register, StatusReg, WaveformReg,
+    LibrarySelectionReg, ModeReg, Register, StatusReg,
 };
 
 pub struct Drv2605l<I2C, E>
@@ -133,33 +133,31 @@ where
 
     /// Sets up to 8 Effects to play in order when `set_go` is called. Stops
     /// playing early if `Effect::None` is used.
+    /// todo dont hardcode to 8, pass slice?
     pub fn set_rom(&mut self, roms: &[Effect; 8]) -> Result<(), DrvError> {
-        // Todo The MSB of each sequence register can implement a delay between
-        // sequence waveforms. When the MSB is high, bits [6:0] indicate the
-        // length of the wait time. The wait time for that step then becomes
-        // WAV_FRM_SEQ[6:0] × 10 ms
         let buf: [u8; 9] = [
             Register::WaveformSequence0 as u8,
-            roms[0] as u8,
-            roms[1] as u8,
-            roms[2] as u8,
-            roms[3] as u8,
-            roms[4] as u8,
-            roms[5] as u8,
-            roms[6] as u8,
-            roms[7] as u8,
+            roms[0].into(),
+            roms[1].into(),
+            roms[2].into(),
+            roms[3].into(),
+            roms[4].into(),
+            roms[5].into(),
+            roms[6].into(),
+            roms[7].into(),
         ];
         self.i2c
             .write(ADDRESS, &buf)
             .map_err(|_| DrvError::ConnectionError)
     }
 
-    /// Set a single Rom to play during rom mode when `set_go` is called
-    pub fn set_rom_single(&mut self, effect: Effect) -> Result<(), DrvError> {
+    /// Set a single `Effect` into rom storage
+    /// during rom mode when `set_go` is called
+    pub fn set_rom_single(&mut self, rom: Effect) -> Result<(), DrvError> {
         let buf: [u8; 3] = [
             Register::WaveformSequence0 as u8,
-            WaveformReg::new_effect(effect).0,
-            WaveformReg::new_stop().0,
+            rom.into(),
+            Effect::Stop.into(),
         ];
         self.i2c
             .write(ADDRESS, &buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,998 +1,59 @@
-/*!
-A platform agnostic Rust friver for the drv2605, based on the
-[`embedded-hal`] traits.
-*/
 #![no_std]
 
-use bitfield::bitfield;
+mod registers;
+pub use crate::registers::Effect;
+use crate::registers::*;
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
-bitfield! {
-    pub struct StatusReg(u8);
-    impl Debug;
-    /// Latching overcurrent detection flag.  If the load impedance is below
-    /// the load-impedance threshold, the device shuts down and periodically
-    /// attempts to restart until the impedance is above the threshold
-    pub oc_detected, _: 0;
-    /// Latching overtemperature detection flag. If the device becomes too hot,
-    /// it shuts down. This bit clears upon read.
-    pub over_temp, _: 1;
-    /// Contains status for the feedback controller. This indicates when the ERM
-    /// back-EMF has been zero for more than ~10 ms in ERM mode, and
-    /// indicates when the LRA frequency tracking has lost frequency lock in LRA
-    /// mode. This bit is for debug purposes only, and may sometimes be set
-    /// under normal operation when extensive braking periods are used. This bit
-    /// will clear upon read.
-    pub feedback_controller_timed_out, _: 2;
-    /// This flag stores the result of the auto-calibration routine and the diagnostic
-    /// routine. The flag contains the result for whichever routine was executed
-    /// last. The flag clears upon read. Test result is not valid until the GO bit self-
-    /// clears at the end of the routine.
-    /// Auto-calibration mode:
-    /// 0: Auto-calibration passed (optimum result converged)
-    /// 1: Auto-calibration failed (result did not converge)
-    /// Diagnostic mode:
-    /// 0: Actuator is functioning normally
-    /// 1: Actuator is not present or is shorted, timing out, or giving
-    /// out–of-range back-EMF.
-    pub diagnostic_result, _: 3;
-    /// Device identifier. The DEVICE_ID bit indicates the part number to the user.
-    /// The user software can ascertain the device capabilities by reading this
-    /// register.
-    /// 4: DRV2604 (contains RAM, does not contain licensed ROM library)
-    /// 3: DRV2605 (contains licensed ROM library, does not contain RAM)
-    /// 6: DRV2604L (low-voltage version of the DRV2604 device)
-    /// 7: DRV2605L (low-voltage version of the DRV2605 device)
-    pub device_id, _: 7, 5;
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum Mode {
-    /// Waveforms are fired by setting the GO bit in register 0x0C.
-    InternalTrigger = 0,
-    /// A rising edge on the IN/TRIG pin sets the GO Bit. A second rising
-    /// edge on the IN/TRIG pin cancels the waveform if the second rising
-    /// edge occurs before the GO bit has cleared.
-    ExternalTriggerRisingEdge = 1,
-    /// The GO bit follows the state of the external trigger. A rising edge on
-    /// the IN/TRIG pin sets the GO bit, and a falling edge sends a cancel. If
-    /// the GO bit is already in the appropriate state, no change occurs.
-    ExternalTriggerLevelMode = 2,
-    /// A PWM or analog signal is accepted at the IN/TRIG pin and used as
-    /// the driving source. The device actively drives the actuator while in
-    /// this mode. The PWM or analog input selection occurs by using the
-    /// N_PWM_ANALOG bit.
-    PwmInputAndAnalogInput = 3,
-    /// An AC-coupled audio signal is accepted at the IN/TRIG pin. The
-    /// device converts the audio signal into meaningful haptic vibration. The
-    /// AC_COUPLE and N_PWM_ANALOG bits should also be set.
-    AudioToVibe = 4,
-    /// The device actively drives the actuator with the contents of the
-    /// RTP_INPUT\[7:0\] bit in register 0x02.
-    RealTimePlayback = 5,
-    /// Set the device in this mode to perform a diagnostic test on the
-    /// actuator. The user must set the GO bit to start the test. The test is
-    /// complete when the GO bit self-clears. Results are stored in the
-    /// DIAG_RESULT bit in register 0x00.
-    Diagnostics = 6,
-    /// Set the device in this mode to auto calibrate the device for the
-    /// actuator. Before starting the calibration, the user must set the all
-    /// required input parameters. The user must set the GO bit to start the
-    /// calibration. Calibration is complete when the GO bit self-clears.
-    AutoCalibration = 7,
-}
-
-impl From<u8> for Mode {
-    fn from(val: u8) -> Mode {
-        match val {
-            0 => Mode::InternalTrigger,
-            1 => Mode::ExternalTriggerRisingEdge,
-            2 => Mode::ExternalTriggerLevelMode,
-            3 => Mode::PwmInputAndAnalogInput,
-            4 => Mode::AudioToVibe,
-            5 => Mode::RealTimePlayback,
-            6 => Mode::Diagnostics,
-            7 => Mode::AutoCalibration,
-            _ => unreachable!("impossible value read back from Mode register"),
-        }
-    }
-}
-
-bitfield! {
-    pub struct ModeReg(u8);
-    impl Debug;
-    /// Device reset. Setting this bit performs the equivalent operation of power
-    /// cycling the device. Any playback operations are immediately interrupted,
-    /// and all registers are reset to the default values. The DEV_RESET bit self-
-    /// clears after the reset operation is complete.
-    pub dev_reset, set_dev_reset: 7;
-
-    /// Software standby mode
-    /// 0: Device ready
-    /// 1: Device in software standby
-    pub standby, set_standby: 6;
-
-    /// The `Mode`
-    pub into Mode, mode, set_mode: 2, 0;
-}
-
-#[derive(Debug)]
-pub struct RatedVoltageReg(u8);
-
-impl Default for RatedVoltageReg {
-    fn default() -> Self {
-        Self(0x3f)
-    }
-}
-
-#[derive(Debug)]
-pub struct OverdriveClampReg(u8);
-
-impl Default for OverdriveClampReg {
-    fn default() -> Self {
-        Self(0x89)
-    }
-}
-
-#[derive(Debug)]
-pub struct AutoCalibrationCompensationReg(u8);
-
-impl Default for AutoCalibrationCompensationReg {
-    fn default() -> Self {
-        Self(0x0D)
-    }
-}
-
-#[derive(Debug)]
-pub struct AutoCalibrationCompensationBackEmfReg(u8);
-
-impl Default for AutoCalibrationCompensationBackEmfReg {
-    fn default() -> Self {
-        Self(0x6D)
-    }
-}
-
-impl Default for ModeReg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_dev_reset(false);
-        reg.set_standby(true);
-        reg.set_mode(0);
-        reg
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum LibrarySelection {
-    Empty = 0,
-    A = 1,
-    B = 2,
-    C = 3,
-    D = 4,
-    E = 5,
-    LRA = 6,
-    Reserved = 7,
-}
-
-impl From<u8> for LibrarySelection {
-    fn from(val: u8) -> LibrarySelection {
-        match val {
-            0 => LibrarySelection::Empty,
-            1 => LibrarySelection::A,
-            2 => LibrarySelection::B,
-            3 => LibrarySelection::C,
-            4 => LibrarySelection::D,
-            5 => LibrarySelection::E,
-            6 => LibrarySelection::LRA,
-            7 => LibrarySelection::Reserved,
-            _ => unreachable!("impossible LibrarySelection value"),
-        }
-    }
-}
-
-bitfield! {
-    pub struct RegisterThree(u8);
-    impl Debug;
-    /// This bit sets the output driver into a true high-impedance state. The device
-    /// must be enabled to go into the high-impedance state. When in hardware
-    /// shutdown or standby mode, the output drivers have 15 kΩ to ground. When
-    /// the HI_Z bit is asserted, the hi-Z functionality takes effect immediately, even
-    /// if a transaction is taking place.
-    pub hi_z, set_hi_z: 4;
-
-    /// Waveform library selection value. This bit determines which library the
-    /// playback engine selects when the GO bit is set.
-    pub into LibrarySelection, library_selection, set_library_selection: 2, 0;
-}
-
-/// Identifies which of the waveforms from the ROM library that should
-/// be played in a given waveform slot.
-#[derive(Debug, Clone, Copy)]
-pub enum Effect {
-    /// Strong Click - 100%
-    StrongClick100 = 1,
-    /// Strong Click - 60%
-    StrongClick60 = 2,
-    /// Strong Click - 30%
-    StrongClick30 = 3,
-    /// Sharp Click - 100%
-    SharpClick100 = 4,
-    /// Sharp Click - 60%
-    SharpClick60 = 5,
-    /// Sharp Click - 30%
-    SharpClick30 = 6,
-    /// Soft Bump - 100%
-    SoftBump100 = 7,
-    /// Soft Bump - 60%
-    SoftBump60 = 8,
-    /// Soft Bump - 30%
-    SoftBump30 = 9,
-    /// Double Click - 100%
-    DoubleClick100 = 10,
-    /// Double Click - 60%
-    DoubleClick60 = 11,
-    /// Triple Click - 100%
-    TripleClick100 = 12,
-    /// Soft Fuzz - 60%
-    SoftFuzz60 = 13,
-    /// Strong Buzz - 100%
-    StrongBuzz100 = 14,
-    /// 750 ms Alert 100%
-    Alert750ms = 15,
-    /// 1000 ms Alert 100%
-    Alert1000ms = 16,
-    /// Strong Click 1 - 100%
-    StrongClickOne100 = 17,
-    /// Strong Click 2 - 80%
-    StrongClickTwo80 = 18,
-    /// Strong Click 3 - 60%
-    StrongClickThree60 = 19,
-    /// Strong Click 4 - 30%
-    StrongClickFour30 = 20,
-    /// Medium Click 1 - 100%
-    MediumClickOne100 = 21,
-    /// Medium Click 2 - 80%
-    MediumClickTwo80 = 22,
-    /// Medium Click 3 - 60%
-    MediumClickThree60 = 23,
-    /// Sharp Tick 1 - 100%
-    SharpTickOne100 = 24,
-    /// Sharp Tick 2 - 80%
-    SharpTickTwo80 = 25,
-    /// Sharp Tick 3 - 60%
-    SharpTickThree60 = 26,
-    /// Short Double Click Strong 1 - 100%
-    ShortDoubleClickStrongOne100 = 27,
-    /// Short Double Click Strong 2 - 80%
-    ShortDoubleClickStrongTwo80 = 28,
-    /// Short Double Click Strong 3 - 60%
-    ShortDoubleClickStrongThree60 = 29,
-    /// Short Double Click Strong 4 - 30%
-    ShortDoubleClickStrongFour30 = 30,
-    /// Short Double Click Medium 1 - 100%
-    ShortDoubleClickMediumOne100 = 31,
-    /// Short Double Click Medium 2 - 80%
-    ShortDoubleClickMediumTwo80 = 32,
-    /// Short Double Click Medium 3 - 60%
-    ShortDoubleClickMediumThree60 = 33,
-    /// Short Double Sharp Tick 1 - 100%
-    ShortDoubleSharpTickOne100 = 34,
-    /// Short Double Sharp Tick 2 - 80%
-    ShortDoubleSharpTickTwo80 = 35,
-    /// Short Double Sharp Tick 3 - 60%
-    ShortDoubleSharpTickThree60 = 36,
-    /// Long Double Sharp Click Strong 1 - 100%
-    LongDoubleSharpClickStrongOne100 = 37,
-    /// Long Double Sharp Click Strong 2 - 80%
-    LongDoubleSharpClickStrongTwo80 = 38,
-    /// Long Double Sharp Click Strong 3 - 60%
-    LongDoubleSharpClickStrongThree60 = 39,
-    /// Long Double Sharp Click Strong 4 - 30%
-    LongDoubleSharpClickStrongFour30 = 40,
-    /// Long Double Sharp Click Medium 1 - 100%
-    LongDoubleSharpClickMediumOne100 = 41,
-    /// Long Double Sharp Click Medium 2 - 80%
-    LongDoubleSharpClickMediumTwo80 = 42,
-    /// Long Double Sharp Click Medium 3 - 60%
-    LongDoubleSharpClickMediumThree60 = 43,
-    /// Long Double Sharp Tick 1 - 100%
-    LongDoubleSharpTickOne100 = 44,
-    /// Long Double Sharp Tick 2 - 80%
-    LongDoubleSharpTickTwo80 = 45,
-    /// Long Double Sharp Tick 3 - 60%
-    LongDoubleSharpTickThree60 = 46,
-    /// Buzz 1 - 100%
-    BuzzOne100 = 47,
-    /// Buzz 2 - 80%
-    BuzzTwo80 = 48,
-    /// Buzz 3 - 60%
-    BuzzThree60 = 49,
-    /// Buzz 4 - 40%
-    BuzzFour40 = 50,
-    /// Buzz 5 - 20%
-    BuzzFive20 = 51,
-    /// Pulsing Strong 1 - 100%
-    PulsingStrongOne100 = 52,
-    /// Pulsing Strong 2 - 60%
-    PulsingStrongTwo60 = 53,
-    /// Pulsing Medium 1 - 100%
-    PulsingMediumOne100 = 54,
-    /// Pulsing Medium 2 - 60%
-    PulsingMediumTwo60 = 55,
-    /// Pulsing Sharp 1 - 100%
-    PulsingSharpOne100 = 56,
-    /// Pulsing Sharp 2 - 60%
-    PulsingSharpTwo60 = 57,
-    /// Transition Click 1 - 100%
-    TransitionClickOne100 = 58,
-    /// Transition Click 2 - 80%
-    TransitionClickTwo80 = 59,
-    /// Transition Click 3 - 60%
-    TransitionClickThree60 = 60,
-    /// Transition Click 4 - 40%
-    TransitionClickFour40 = 61,
-    /// Transition Click 5 - 20%
-    TransitionClickFive20 = 62,
-    /// Transition Click 6 - 10%
-    TransitionClickSix10 = 63,
-    /// Transition Hum 1 - 100%
-    TransitionHumOne100 = 64,
-    /// Transition Hum 2 - 80%
-    TransitionHumTwo80 = 65,
-    /// Transition Hum 3 - 60%
-    TransitionHumThree60 = 66,
-    /// Transition Hum 4 - 40%
-    TransitionHumFour40 = 67,
-    /// Transition Hum 5 - 20%
-    TransitionHumFive20 = 68,
-    /// Transition Hum 6 - 10%
-    TransitionHumSix10 = 69,
-    /// Transition Ramp Down Long Smooth 1 - 100 to 0%
-    TransitionRampDownLongSmoothOne100to0 = 70,
-    /// Transition Ramp Down Long Smooth 2 - 100 to 0%
-    TransitionRampDownLongSmoothTwo100to0 = 71,
-    /// Transition Ramp Down Medium Smooth 1 - 100 to 0%
-    TransitionRampDownMediumSmoothOne100to0 = 72,
-    /// Transition Ramp Down Medium Smooth 2 - 100 to 0%
-    TransitionRampDownMediumSmoothTwo100to0 = 73,
-    /// Transition Ramp Down Short Smooth 1 - 100 to 0%
-    TransitionRampDownShortSmoothOne100to0 = 74,
-    /// Transition Ramp Down Short Smooth 2 - 100 to 0%
-    TransitionRampDownShortSmoothTwo100to0 = 75,
-    /// Transition Ramp Down Long Sharp 1 - 100 to 0%
-    TransitionRampDownLongSharpOne100to0 = 76,
-    /// Transition Ramp Down Long Sharp 2 - 100 to 0%
-    TransitionRampDownLongSharpTwo100to0 = 77,
-    /// Transition Ramp Down Medium Sharp 1 - 100 to 0%
-    TransitionRampDownMediumSharpOne100to0 = 78,
-    /// Transition Ramp Down Medium Sharp 2 - 100 to 0%
-    TransitionRampDownMediumSharpTwo100to0 = 79,
-    /// Transition Ramp Down Short Sharp 1 - 100 to 0%
-    TransitionRampDownShortSharpOne100to0 = 80,
-    /// Transition Ramp Down Short Sharp 2 - 100 to 0%
-    TransitionRampDownShortSharpTwo100to0 = 81,
-    /// Transition Ramp Up Long Smooth 1 - 0 to 100%
-    TransitionRampUpLongSmoothOne0to100 = 82,
-    /// Transition Ramp Up Long Smooth 2 - 0 to 100%
-    TransitionRampUpLongSmoothTwo0to100 = 83,
-    /// Transition Ramp Up Medium Smooth 1 - 0 to 100%
-    TransitionRampUpMediumSmoothOne0to100 = 84,
-    /// Transition Ramp Up Medium Smooth 2 - 0 to 100%
-    TransitionRampUpMediumSmoothTwo0to100 = 85,
-    /// Transition Ramp Up Short Smooth 1 - 0 to 100%
-    TransitionRampUpShortSmoothOne0to100 = 86,
-    /// Transition Ramp Up Short Smooth 2 - 0 to 100%
-    TransitionRampUpShortSmoothTwo0to100 = 87,
-    /// Transition Ramp Up Long Sharp 1 - 0 to 100%
-    TransitionRampUpLongSharpOne0to100 = 88,
-    /// Transition Ramp Up Long Sharp 2 - 0 to 100%
-    TransitionRampUpLongSharpTwo0to100 = 89,
-    /// Transition Ramp Up Medium Sharp 1 - 0 to 100%
-    TransitionRampUpMediumSharpOne0to100 = 90,
-    /// Transition Ramp Up Medium Sharp 2 - 0 to 100%
-    TransitionRampUpMediumSharpTwo0to100 = 91,
-    /// Transition Ramp Up Short Sharp 1 - 0 to 100%
-    TransitionRampUpShortSharpOne0to100 = 92,
-    /// Transition Ramp Up Short Sharp 2 - 0 to 100%
-    TransitionRampUpShortSharpTwo0to100 = 93,
-    /// Transition Ramp Down Long Smooth 1 - 50 to 0%
-    TransitionRampDownLongSmoothOne50to0 = 94,
-    /// Transition Ramp Down Long Smooth 2 - 50 to 0%
-    TransitionRampDownLongSmoothTwo50to0 = 95,
-    /// Transition Ramp Down Medium Smooth 1 - 50 to 0%
-    TransitionRampDownMediumSmoothOne50to0 = 96,
-    /// Transition Ramp Down Medium Smooth 2 - 50 to 0%
-    TransitionRampDownMediumSmoothTwo50to0 = 97,
-    /// Transition Ramp Down Short Smooth 1 - 50 to 0%
-    TransitionRampDownShortSmoothOne50to0 = 98,
-    /// Transition Ramp Down Short Smooth 2 - 50 to 0%
-    TransitionRampDownShortSmoothTwo50to0 = 99,
-    /// Transition Ramp Down Long Sharp 1 - 50 to 0%
-    TransitionRampDownLongSharpOne50to0 = 100,
-    /// Transition Ramp Down Long Sharp 2 - 50 to 0%
-    TransitionRampDownLongSharpTwo50to0 = 101,
-    /// Transition Ramp Down Medium Sharp 1 - 50 to 0%
-    TransitionRampDownMediumSharpOne50to0 = 102,
-    /// Transition Ramp Down Medium Sharp 2 - 50 to 0%
-    TransitionRampDownMediumSharpTwo50to0 = 103,
-    /// Transition Ramp Down Short Sharp 1 - 50 to 0%
-    TransitionRampDownShortSharpOne50to0 = 104,
-    /// Transition Ramp Down Short Sharp 2 - 50 to 0%
-    TransitionRampDownShortSharpTwo50to0 = 105,
-    /// Transition Ramp Up Long Smooth 1 - 0 to 50%
-    TransitionRampUpLongSmoothOne0to50 = 106,
-    /// Transition Ramp Up Long Smooth 2 - 0 to 50%
-    TransitionRampUpLongSmoothTwo0to50 = 107,
-    /// Transition Ramp Up Medium Smooth 1 - 0 to 50%
-    TransitionRampUpMediumSmoothOne0to50 = 108,
-    /// Transition Ramp Up Medium Smooth 2 - 0 to 50%
-    TransitionRampUpMediumSmoothTwo0to50 = 109,
-    /// Transition Ramp Up Short Smooth 1 - 0 to 50%
-    TransitionRampUpShortSmoothOne0to50 = 110,
-    /// Transition Ramp Up Short Smooth 2 - 0 to 50%
-    TransitionRampUpShortSmoothTwo0to50 = 111,
-    /// Transition Ramp Up Long Sharp 1 - 0 to 50%
-    TransitionRampUpLongSharpOne0to50 = 112,
-    /// Transition Ramp Up Long Sharp 2 - 0 to 50%
-    TransitionRampUpLongSharpTwo0to50 = 113,
-    /// Transition Ramp Up Medium Sharp 1 - 0 to 50%
-    TransitionRampUpMediumSharpOne0to50 = 114,
-    /// Transition Ramp Up Medium Sharp 2 - 0 to 50%
-    TransitionRampUpMediumSharpTwo0to50 = 115,
-    /// Transition Ramp Up Short Sharp 1 - 0 to 50%
-    TransitionRampUpShortSharpOne0to50 = 116,
-    /// Transition Ramp Up Short Sharp 2 - 0 to 50%
-    TransitionRampUpShortSharpTwo0to50 = 117,
-    /// Long Buzz For Programmatic Stopping - 100%
-    LongBuzzForProgrammaticStopping100 = 118,
-    /// Smooth Hum 1 (No kick or brake pulse) - 50%
-    SmoothHumOne50 = 119,
-    /// Smooth Hum 2 (No kick or brake pulse) - 40%
-    SmoothHumTwo40 = 120,
-    /// Smooth Hum 3 (No kick or brake pulse) - 30%
-    SmoothHumThree30 = 121,
-    /// Smooth Hum 4 (No kick or brake pulse) - 20%
-    SmoothHumFour20 = 122,
-    /// Smooth Hum 5 (No kick or brake pulse) - 10%
-    SmoothHumFive10 = 123,
-}
-
-bitfield! {
-    pub struct WaveformReg(u8);
-    impl Debug;
-    /// When this bit is set, the WAV_FRM_SEQ[6:0] bit is interpreted as a wait
-    /// time in which the playback engine idles. This bit is used to insert timed
-    /// delays between sequentially played waveforms.
-    /// Delay time = 10 ms × WAV_FRM_SEQ[6:0]
-    /// If WAIT = 0, then WAV_FRM_SEQ[6:0] is interpreted as a waveform
-    /// identifier for sequence playback.
-    wait, set_wait: 7;
-
-    /// Waveform sequence value. This bit holds the waveform identifier of the
-    /// waveform to be played. A waveform identifier is an integer value referring
-    /// to the index position of a waveform in a ROM library. Playback begins at
-    /// register address 0x04 when the user asserts the GO bit (register 0x0C).
-    /// When playback of that waveform ends, the waveform sequencer plays the
-    /// next waveform identifier held in register 0x05, if the next waveform
-    /// identifier is non-zero. The waveform sequencer continues in this way until
-    /// the sequencer reaches an identifier value of zero, or all eight identifiers are
-    /// played (register addresses 0x04 through 0x0B), whichever comes first.
-    waveform_seq, set_waveform_seq: 6, 0;
-}
-
-impl WaveformReg {
-    /// Stops playing the sequence of effects
-    pub fn new_stop() -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(false);
-        w.set_waveform_seq(0);
-        w
-    }
-
-    /// Set the effect
-    pub fn new_effect(effect: Effect) -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(false);
-        w.set_waveform_seq(effect as u8);
-        w
-    }
-
-    /// Wait the specified amount of time (in 10ms intervals), before
-    /// moving to the next effect and playing it.
-    pub fn new_wait_time(tens_of_ms: u8) -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(true);
-        w.set_waveform_seq(tens_of_ms);
-        w
-    }
-}
-
-bitfield! {
-    pub struct GoReg(u8);
-    impl Debug;
-    /// This bit is used to fire processes in the DRV2605 device. The process
-    /// fired by the GO bit is selected by the MODE[2:0] bit (register 0x01). The
-    /// primary function of this bit is to fire playback of the waveform identifiers in
-    /// the waveform sequencer (registers 0x04 to 0x0B), in which case, this bit
-    /// can be thought of a software trigger for haptic waveforms. The GO bit
-    /// remains high until the playback of the haptic waveform sequence is
-    /// complete. Clearing the GO bit during waveform playback cancels the
-    /// waveform sequence. Using one of the external trigger modes can cause
-    /// the GO bit to be set or cleared by the external trigger pin. This bit can also
-    /// be used to fire the auto-calibration process or the diagnostic process.
-    pub go, set_go: 0;
-}
-
-bitfield! {
-    pub struct FeedbackControlReg(u8);
-    impl Debug;
-
-    /// This bit sets the DRV2605 device in ERM or LRA mode. This bit should be set
-    /// prior to running auto calibration.
-    /// 0: ERM Mode
-    /// 1: LRA Mode
-    pub n_erm_lra, set_n_erm_lra: 7;
-
-    /// This bit selects the feedback gain ratio between braking gain and driving gain.
-    /// In general, adding additional feedback gain while braking is desirable so that the
-    /// actuator brakes as quickly as possible. Large ratios provide less-stable
-    /// operation than lower ones. The advanced user can select to optimize this
-    /// register. Otherwise, the default value should provide good performance for most
-    /// actuators. This value should be set prior to running auto calibration.
-    /// 0: 1x
-    /// 1: 2x
-    /// 2: 3x
-    /// 3: 4x
-    /// 4: 6x
-    /// 5: 8x
-    /// 6: 16x
-    /// 7: Braking disabled
-    pub fb_brake_factor, set_fb_brake_factor: 6, 4;
-
-    /// This bit selects a loop gain for the feedback control. The LOOP_GAIN[1:0] bit
-    /// sets how fast the loop attempts to make the back-EMF (and thus motor velocity)
-    /// match the input signal level. Higher loop-gain (faster settling) options provide
-    /// less-stable operation than lower loop gain (slower settling). The advanced user
-    /// can select to optimize this register. Otherwise, the default value should provide
-    /// good performance for most actuators. This value should be set prior to running
-    /// auto calibration.
-    /// 0: Low
-    /// 1: Medium (default)
-    /// 2: High
-    /// 3: Very High
-    pub loop_gain, set_loop_gain: 3, 2;
-
-    /// This bit sets the analog gain of the back-EMF amplifier. This value is interpreted
-    /// differently between ERM mode and LRA mode. Auto calibration automatically
-    /// populates the BEMF_GAIN bit with the most appropriate value for the actuator.
-    /// ERM Mode
-    /// 0: 0.33x
-    /// 1: 1.0x
-    /// 2: 1.8x (default)
-    /// 3: 4.0x
-    /// LRA Mode
-    /// 0: 5x
-    /// 1: 10x
-    /// 2: 20x (default)
-    /// 3: 30x
-    pub bemf_gain, set_bemf_gain: 1, 0;
-}
-
-impl Default for FeedbackControlReg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_n_erm_lra(false);
-        reg.set_fb_brake_factor(0x3);
-        reg.set_loop_gain(0x1);
-        reg.set_bemf_gain(0x2);
-        reg
-    }
-}
-
-bitfield! {
-    pub struct Control1Reg(u8);
-    impl Debug;
-    /// This bit applies higher loop gain during overdrive to enhance actuator transient response.
-    pub startup_boost, set_startup_boost: 7;
-    /// This bit applies a 0.9-V common mode voltage to the IN/TRIG pin when an AC-
-    /// coupling capacitor is used. This bit is only useful for analog input mode. This bit
-    /// should not be asserted for PWM mode or external trigger mode.
-    /// 0: Common-mode drive disabled for DC-coupling or digital inputs modes
-    /// 1: Common-mode drive enabled for AC coupling
-    pub ac_couple, set_ac_couple: 5;
-    /// LRA Mode: Sets initial guess for LRA drive-time in LRA mode. Drive time is
-    /// automatically adjusted for optimum drive in real time; however, this register
-    /// should be optimized for the approximate LRA frequency. If the bit is set too low,
-    /// it can affect the actuator startup time. If it is set too high, it can cause instability.
-    /// Optimum drive time (ms) ≈ 0.5 × LRA Period
-    /// Drive time (ms) = DRIVE_TIME[4:0] × 0.1 ms + 0.5 ms
-    /// ERM Mode: Sets the sample rate for the back-EMF detection. Lower drive times
-    /// cause higher peak-to-average ratios in the output signal, requiring more supply
-    /// headroom. Higher drive times cause the feedback to react at a slower rate.
-    /// Drive Time (ms) = DRIVE_TIME[4:0] × 0.2 ms + 1 ms
-    pub drive_time, set_drive_time: 4, 0;
-}
-
-impl Default for Control1Reg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_startup_boost(true);
-        reg.set_ac_couple(false);
-        reg.set_drive_time(0x13);
-        reg
-    }
-}
-
-bitfield! {
-    pub struct Control2Reg(u8);
-    impl Debug;
-    /// The BIDIR_INPUT bit selects how the engine interprets data.
-    /// 0: Unidirectional input mode
-    /// Braking is automatically determined by the feedback conditions and is
-    /// applied when needed. Use of this mode also recovers an additional bit
-    /// of vertical resolution. This mode should only be used for closed-loop
-    /// operation.
-    /// Examples::
-    /// 0% Input -> No output signal
-    /// 50% Input -> Half-scale output signal
-    /// 100% Input -> Full-scale output signal
-    /// 1: Bidirectional input mode (default)
-    /// This mode is compatible with traditional open-loop signaling and also
-    /// works well with closed-loop mode. When operating closed-loop, braking
-    /// is automatically determined by the feedback conditions and applied
-    /// when needed. When operating open-loop modes, braking is only
-    /// applied when the input signal is less than 50%.
-    /// Open-loop mode (ERM and LRA) examples:
-    /// 0% Input -> Negative full-scale output signal (braking)
-    /// 25% Input -> Negative half-scale output signal (braking)
-    /// 50% Input -> No output signal
-    /// 75% Input -> Positive half-scale output signal
-    /// 100% Input -> Positive full-scale output signal
-    /// Closed-loop mode (ERM and LRA) examples:
-    /// 0% to 50% Input -> No output signal
-    /// 50% Input -> No output signal
-    /// 75% Input -> Half-scale output signal
-    /// 100% Input -> Full-scale output signal
-    pub bidir_input, set_bidir_input: 7;
-    /// When this bit is set, loop gain is reduced when braking is almost complete to
-    /// improve loop stability
-    pub brake_stabilizer, set_brake_stabilizer: 6;
-    /// LRA auto-resonance sampling time (Advanced use only)
-    /// 0: 150 us
-    /// 1: 200 us
-    /// 2: 250 us
-    /// 3: 300 us
-    pub sample_time, set_sample_time: 5, 4;
-    /// Blanking time before the back-EMF AD makes a conversion. (Advanced use only)
-    pub blanking_time, set_blanking_time: 3, 2;
-    /// Current dissipation time. This bit is the time allowed for the current to dissipate
-    /// from the actuator between PWM cycles for flyback mitigation. (Advanced use
-    /// only)
-    pub idiss_time, set_idiss_time: 1, 0;
-}
-
-impl Default for Control2Reg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_bidir_input(true);
-        reg.set_brake_stabilizer(true);
-        reg.set_sample_time(0x3);
-        reg.set_blanking_time(0x1);
-        reg.set_idiss_time(0x1);
-        reg
-    }
-}
-
-bitfield! {
-    pub struct Control3Reg(u8);
-    impl Debug;
-
-    /// This bit is the noise-gate threshold for PWM and analog inputs.
-    /// 0: Disabled
-    /// 1: 2%
-    /// 2: 4% (Default)
-    /// 3: 8%
-    pub ng_thresh, set_ng_thresh: 7, 6;
-    /// This bit selects mode of operation while in ERM mode. Closed-loop operation is
-    /// usually desired for because of automatic overdrive and braking properties.
-    /// However, many existing waveform libraries were designed for open-loop
-    /// operation, so open-loop operation may be required for compatibility.
-    /// 0: Closed Loop
-    /// 1: Open Loop
-    pub erm_open_loop, set_erm_open_loop: 5;
-    /// This bit disables supply compensation. The DRV2605 device generally provides
-    /// constant drive output over variation in the power supply input (V DD ). In some
-    /// systems, supply compensation may have already been implemented upstream,
-    /// so disabling the DRV2605 supply compensation can be useful.
-    /// 0: Supply compensation enabled
-    /// 1: Supply compensation disabled
-    pub supply_comp_dis, set_supply_comp_dis: 4;
-    /// This bit selects the input data interpretation for RTP (Real-Time Playback)
-    /// mode.
-    /// 0: Signed
-    /// 1: Unsigned
-    pub data_format_rtp, set_data_format_rtp: 3;
-    /// This bit selects the drive mode for the LRA algorithm. This bit determines how
-    /// often the drive amplitude is updated. Updating once per cycle provides a
-    /// symmetrical output signal, while updating twice per cycle provides more precise
-    /// control.
-    /// 0: Once per cycle
-    /// 1: Twice per cycle
-    pub lra_drive_mode, set_lra_drive_mode: 2;
-    /// This bit selects the input mode for the IN/TRIG pin when MODE[2:0] = 3. In
-    /// PWM input mode, the duty cycle of the input signal determines the amplitude of
-    /// the waveform. In analog input mode, the amplitude of the input determines the
-    /// amplitude of the waveform.
-    /// 0: PWM Input
-    /// 1: Analog Input
-    pub n_pwm_analog, set_n_pwm_analog: 1;
-    /// This bit selects an open-loop drive option for LRA Mode. When asserted, the
-    /// playback engine drives the LRA at the selected frequency independently of the
-    /// resonance frequency. In PWM input mode, the playback engine recovers the
-    /// LRA commutation frequency from the PWM input, dividing the frequency by
-    /// 128. Therefore the PWM input frequency must be equal to 128 times the
-    /// resonant frequency of the LRA.
-    /// 0: Auto-resonance mode
-    /// 1: LRA open-loop mode
-    pub lra_open_loop, set_lra_open_loop: 0;
-}
-
-impl Default for Control3Reg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_ng_thresh(0x2);
-        reg.set_erm_open_loop(true);
-        reg.set_supply_comp_dis(false);
-        reg.set_data_format_rtp(false);
-        reg.set_lra_drive_mode(false);
-        reg.set_n_pwm_analog(false);
-        reg.set_lra_open_loop(false);
-        reg
-    }
-}
-
-bitfield! {
-    pub struct Control4Reg(u8);
-    impl Debug;
-
-    /// This bit sets the minimum length of time devoted for detecting a zero crossing.
-    /// (advanced use only). Only documented on l models?
-    /// 0: 100 us (Default)
-    /// 1: 200 us
-    /// 2: 300 us
-    /// 3: 390 us
-    pub zc_det_time, set_zc_det_time: 7, 6;
-
-    /// This bit sets the length of the auto calibration time. The AUTO_CAL_TIME[1:0]
-    /// bit should be enough time for the motor acceleration to settle when driven at the
-    /// RATED_VOLTAGE[7:0] value.
-    /// 0: 150 ms (minimum), 350 ms (maximum)
-    /// 1: 250 ms (minimum), 450 ms (maximum)
-    /// 2: 500 ms (minimum), 700 ms (maximum)
-    /// 3: 1000 ms (minimum), 1200 ms (maximum)
-    pub auto_cal_time, set_auto_cal_time: 5, 4;
-
-    /// OTP Memory status
-    /// 0: OTP Memory has not been programmed
-    /// 1: OTP Memory has been programmed
-    pub otp_status, set_otp_status: 2;
-
-    /// This bit launches the programming process for one-time programmable (OTP)
-    /// memory which programs the contents of register 0x16 through 0x1A into
-    /// nonvolatile memory. This process can only be executed one time per device.
-    /// See the Programming On-Chip OTP Memory section for details.
-    pub otp_program, set_otp_program: 1;
-}
-
-impl Default for Control4Reg {
-    fn default() -> Self {
-        let mut reg = Self(0);
-        reg.set_auto_cal_time(0x2);
-        reg.set_otp_program(false);
-        reg
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(u8)]
-pub enum Register {
-    Status = 0,
-    Mode = 1,
-    /// This field is the entry point for real-time playback (RTP) data. The DRV2605
-    /// playback engine drives the RTP_INPUT[7:0] value to the load when
-    /// MODE[2:0] = 5 (RTP mode). The RTP_INPUT[7:0] value can be updated in
-    /// real-time by the host controller to create haptic waveforms. The
-    /// RTP_INPUT[7:0] value is interpreted as signed by default, but can be set to
-    /// unsigned by the DATA_FORMAT_RTP bit in register 0x1D. When the
-    /// haptic waveform is complete, the user can idle the device by setting
-    /// MODE[2:0] = 0, or alternatively by setting STANDBY = 1.
-    RealTimePlaybackInput = 2,
-    Register3 = 3,
-    WaveformSequence0 = 4,
-    WaveformSequence1 = 5,
-    WaveformSequence2 = 6,
-    WaveformSequence3 = 7,
-    WaveformSequence4 = 8,
-    WaveformSequence5 = 9,
-    WaveformSequence6 = 0xa,
-    WaveformSequence7 = 0xb,
-    Go = 0xc,
-    OverdriveTimeOffset = 0xd,
-    SustainTimeOffsetPositive = 0xe,
-    SustainTimeOffsetNegative = 0xf,
-    BrakeTimeOffset = 0x10,
-
-    /// This bit sets the reference voltage for full-scale output during closed-loop
-    /// operation. The auto-calibration routine uses this register as an input, so this
-    /// register must be written with the rated voltage value of the motor before
-    /// calibration is performed. This register is ignored for open-loop operation
-    /// because the overdrive voltage sets the reference for that case. Any
-    /// modification of this register value should be followed by calibration to set
-    /// A_CAL_BEMF appropriately.
-    /// See the Rated Voltage Programming section for calculating the correct register
-    /// value.
-    RatedVoltage = 0x16,
-
-    /// During closed-loop operation the actuator feedback allows the output voltage
-    /// to go above the rated voltage during the automatic overdrive and automatic
-    /// braking periods. This register sets a clamp so that the automatic overdrive is
-    /// bounded. This bit also serves as the full-scale reference voltage for open-loop
-    /// operation.
-    /// See the Overdrive Voltage-Clamp Programming section for calculating the
-    /// correct register value.
-    OverdriveClampVoltage = 0x17,
-
-    /// This register contains the voltage-compensation result after execution of auto
-    /// calibration. The value stored in the A_CAL_COMP bit compensates for any
-    /// resistive losses in the driver. The calibration routine checks the impedance of
-    /// the actuator to automatically determine an appropriate value. The auto-
-    /// calibration compensation-result value is multiplied by the drive gain during
-    /// playback.
-    /// Auto-calibration compensation coefficient = 1 + A_CAL_COMP[7:0] / 255
-    AutoCalibrationCompensationResult = 0x18,
-
-    /// This register contains the rated back-EMF result after execution of auto
-    /// calibration. The A_CAL_BEMF[7:0] bit is the level of back-EMF voltage that the
-    /// actuator gives when the actuator is driven at the rated voltage. The DRV2605
-    /// playback engine uses this the value stored in this bit to automatically determine
-    /// the appropriate feedback gain for closed-loop operation.
-    /// Auto-calibration back-EMF (V) = (A_CAL_BEMF[7:0] / 255) × 1.22 V /
-    /// BEMF_GAIN[1:0]
-    AutoCalibrationBackEMFResult = 0x19,
-
-    FeedbackControl = 0x1a,
-
-    Control1 = 0x1b,
-    Control2 = 0x1c,
-    Control3 = 0x1d,
-    Control4 = 0x1e,
-}
-
-pub struct HapticBuilder<I2C, DEV> {
-    rated: RatedVoltageReg,
-    clamp: OverdriveClampReg,
-    ctrl1: Control1Reg,
-    ctrl2: Control2Reg,
-    ctrl4: Control4Reg,
-
-    otp: Option<bool>,
-    open_loop: Option<bool>,
-    auto_calibrate: Option<bool>,
-
-    comp: AutoCalibrationCompensationReg,
-    bemf: AutoCalibrationCompensationBackEmfReg,
-    feedback: FeedbackControlReg,
-
-    _i2c: core::marker::PhantomData<I2C>,
-    _dev: core::marker::PhantomData<DEV>,
-}
-
-impl<DEV, I2C, E> HapticBuilder<I2C, DEV>
+pub struct Drv2605l<I2C, E>
 where
-    DEV: DrvConfig,
     I2C: WriteRead<Error = E> + Write<Error = E>,
 {
-    /// only need inputs if lra I think? and if auto calibrating
-    pub fn new(rated: u8, clamp: u8, drive_time: u8) -> Self {
-        let mut haptic = HapticBuilder::<I2C, DEV>::default();
-        haptic.ctrl1.set_drive_time(drive_time);
-        haptic.rated = RatedVoltageReg(rated);
-        haptic.clamp = OverdriveClampReg(clamp);
-        haptic
-    }
+    i2c: I2C,
+    lra: bool,
+}
 
-    /// Finish building the simulated RGB display and open an SDL window to render it into
-    pub fn auto_calibrate(&mut self, auto_calibrate: bool) -> &mut Self {
-        self.auto_calibrate = Some(auto_calibrate);
-        self
-    }
+#[allow(unused)]
+impl<I2C, E> Drv2605l<I2C, E>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Returns a calibrated Drv2605l Erm device configured to standby mode for
+    /// power savings. Use a `set_mode` and `set_go` to trigger a vibration.
+    pub fn erm(i2c: I2C, calibration: ErmCalibration) -> Result<Self, DrvError> {
+        let mut haptic = Self { i2c, lra: false };
+        haptic.check_id(7)?;
 
-    /// Finish building the simulated RGB display and open an SDL window to render it into
-    pub fn set_open_loop(&mut self, open: bool) -> &mut Self {
-        //todo.. is this good?
-        self.open_loop = Some(open);
-        self
-    }
+        // todo reset so registers are defaulted. Timing out..  need a solution
+        // for delaying and retrying
+        // haptic.reset()?;
 
-    /// Finish building the simulated RGB display and open an SDL window to render it into
-    pub fn otp(&mut self, otp: bool) -> &mut Self {
-        //todo.. is this good?
-        self.auto_calibrate = Some(!otp);
-        self.otp = Some(otp);
-        self
-    }
+        match calibration {
+            // device will get calibration values out of the otp if the otp bit is set
+            ErmCalibration::Otp => {
+                if !haptic.is_otp()? {
+                    return Err(DrvError::OTPNotProgrammed);
+                }
+            }
+            // load up previously calibrated values
+            ErmCalibration::Load(c) => haptic.set_calibration(c)?,
+            ErmCalibration::Auto(c) => {
+                let mut feedback: FeedbackControlReg = Default::default();
+                let mut ctrl2: Control2Reg = Default::default();
+                let mut ctrl4: Control4Reg = Default::default();
 
-    pub fn load_calibration(&mut self, comp: u8, bemf: u8, gain: u8) -> &mut Self {
-        self.feedback.set_bemf_gain(gain);
-        self.comp = AutoCalibrationCompensationReg(comp);
-        self.bemf = AutoCalibrationCompensationBackEmfReg(bemf);
+                feedback.set_fb_brake_factor(c.brake_factor);
+                feedback.set_loop_gain(c.loop_gain);
+                ctrl2.set_sample_time(c.lra_sample_time);
+                ctrl2.set_blanking_time(c.lra_blanking_time);
+                ctrl2.set_idiss_time(c.lra_idiss_time);
+                ctrl4.set_auto_cal_time(c.auto_cal_time);
+                ctrl4.set_zc_det_time(c.lra_zc_det_time);
 
-        //todo.. is this good?
-        self.auto_calibrate = Some(false);
-
-        self
-    }
-
-    pub fn auto_calibration(
-        &mut self,
-        brake_factor: u8,
-        loop_gain: u8,
-        lra_sample_time: u8,
-        lra_blanking_time: u8,
-        lra_idiss_time: u8,
-        auto_cal_time: u8,
-        lra_zc_det_time: u8,
-    ) -> &mut Self {
-        self.feedback.set_fb_brake_factor(brake_factor);
-        self.feedback.set_loop_gain(loop_gain);
-        self.ctrl2.set_sample_time(lra_sample_time);
-        self.ctrl2.set_blanking_time(lra_blanking_time);
-        self.ctrl2.set_idiss_time(lra_idiss_time);
-        self.ctrl4.set_auto_cal_time(auto_cal_time);
-        self.ctrl4.set_zc_det_time(lra_zc_det_time);
-
-        //todo.. is this good?
-        self.auto_calibrate = Some(true);
-
-        self
-    }
-
-    /// Finish building the simulated RGB display and open an SDL window to render it into
-    pub fn connect(&self, i2c: I2C) -> Result<Drv2605<I2C, DEV>, DrvError<E>> {
-        let mut haptic: Drv2605<I2C, DEV> = Drv2605::<I2C, DEV>::new(i2c);
-
-        haptic.check_id(DEV::ID)?;
-
-        //.. just to be conservative?
-        // self.reset()?;
-        //todo wait some amount of time??? probably going to break here
-
-        haptic.write(Register::Control1, self.ctrl1.0)?;
-        haptic.write(Register::Control2, self.ctrl2.0)?;
-        //todo who and when did we figure out between open/closed loop?
-
-        let ctrl3: Control3Reg = Default::default();
-        haptic.write(Register::Control3, ctrl3.0)?;
-
-        haptic.write(Register::Control4, self.ctrl4.0)?;
-
-        haptic.write(Register::RatedVoltage, self.rated.0)?;
-        haptic.write(Register::OverdriveClampVoltage, self.clamp.0)?;
-
-        //todo who and when did we figure out between lra and erm here?
-        haptic.write(Register::FeedbackControl, self.feedback.0)?;
-
-        //may or may not be set. could put in if statement.. but who cares?
-        haptic.write(Register::AutoCalibrationCompensationResult, self.comp.0)?;
-        haptic.write(Register::AutoCalibrationBackEMFResult, self.bemf.0)?;
-
-        haptic.diagnostics()?;
-
-        if self.auto_calibrate.unwrap() {
-            haptic.calibrate()?;
-        } else if self.otp.unwrap() {
-            if !Control4Reg(haptic.read(Register::Control4)?).otp_status() {
-                return Err(DrvError::OTPError);
+                haptic.write(Register::FeedbackControl, feedback.0)?;
+                haptic.write(Register::Control2, ctrl2.0)?;
+                haptic.write(Register::Control4, ctrl4.0)?;
+                haptic.calibrate()?;
             }
         }
 
@@ -1000,124 +61,102 @@ where
 
         Ok(haptic)
     }
-}
 
-impl<DEV, I2C, E> Default for HapticBuilder<I2C, DEV>
-where
-    DEV: DrvConfig,
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-{
-    fn default() -> Self {
-        Self {
-            rated: Default::default(),
-            clamp: Default::default(),
-            ctrl1: Default::default(),
-            ctrl2: Default::default(),
-            ctrl4: Default::default(),
+    /// Returns a calibrated Drv2605l Lra device configured to standby mode for
+    /// power savings. Use a `set_mode` and `set_go` to trigger a vibration.
+    pub fn lra(i2c: I2C, calibration: LraCalibration) -> Result<Self, DrvError> {
+        let mut haptic = Self { i2c, lra: true };
+        haptic.check_id(7)?;
 
-            otp: None,
-            open_loop: None,
-            auto_calibrate: None,
+        // todo reset so registers are defaulted. Timing out..  need a solution
+        // for delaying and retrying
+        // haptic.reset()?;
 
-            comp: Default::default(),
-            bemf: Default::default(),
-            feedback: Default::default(),
+        match calibration {
+            // device will get calibration values out of the otp if the otp bit
+            // is set
+            LraCalibration::Otp => {
+                if !haptic.is_otp()? {
+                    return Err(DrvError::OTPNotProgrammed);
+                }
+            }
+            // load up previously calibrated values
+            LraCalibration::Load(c) => haptic.set_calibration(c)?,
+            LraCalibration::Auto(c, c_lra) => {
+                let mut feedback: FeedbackControlReg = Default::default();
+                let mut ctrl2: Control2Reg = Default::default();
+                let mut ctrl4: Control4Reg = Default::default();
+                let mut ctrl1: Control1Reg = Default::default();
 
-            _i2c: core::marker::PhantomData,
-            _dev: core::marker::PhantomData,
+                feedback.set_fb_brake_factor(c.brake_factor);
+                feedback.set_loop_gain(c.loop_gain);
+                ctrl1.set_drive_time(c_lra.drive_time);
+                ctrl2.set_sample_time(c.lra_sample_time);
+                ctrl2.set_blanking_time(c.lra_blanking_time);
+                ctrl2.set_idiss_time(c.lra_idiss_time);
+                ctrl4.set_auto_cal_time(c.auto_cal_time);
+                ctrl4.set_zc_det_time(c.lra_zc_det_time);
+
+                haptic.write(Register::FeedbackControl, feedback.0)?;
+                haptic.write(Register::RatedVoltage, c_lra.rated)?;
+                haptic.write(Register::OverdriveClampVoltage, c_lra.clamp)?;
+                haptic.write(Register::Control1, ctrl1.0)?;
+                haptic.write(Register::Control2, ctrl2.0)?;
+                haptic.write(Register::Control4, ctrl4.0)?;
+                haptic.calibrate()?;
+            }
         }
+
+        haptic.set_standby(true)?;
+
+        Ok(haptic)
     }
-}
 
-/// The hardcoded address of the driver.  All drivers share the same
-/// address so that it is possible to broadcast on the bus and have
-/// multiple units emit the same waveform
-pub const ADDRESS: u8 = 0x5a;
+    /// Select the Immersion TS2200 library that matches your motor
+    /// characteristic. Afterwards set the rom(s) and thn GO bit to play
+    pub fn set_mode_rom(&mut self, value: ErmLibrary) -> Result<(), DrvError> {
+        let mut mode = ModeReg(self.read(Register::Mode)?);
+        mode.set_mode(Mode::InternalTrigger as u8);
+        self.write(Register::Mode, mode.0)?;
 
-//todo encode open and closed loop in state
-pub struct Drv2605Erm;
-pub struct Drv2605Lra;
-pub struct Drv2604Lra;
-pub struct Drv2604Erm;
-pub struct Drv2605lErm;
-pub struct Drv2605lLra;
-pub struct Drv2604lErm;
-pub struct Drv2604lLra;
+        if !self.lra {
+            // Library A is open loop ONLY, but also says all seem to prefer open
+            // loop for ERM
+            self.set_open_loop(true)?;
+        } else {
+            self.set_open_loop(false)?;
+        }
 
-pub trait DrvConfig {
-    const ID: u8;
-}
-
-impl DrvConfig for Drv2605Erm {
-    const ID: u8 = 3;
-}
-impl DrvConfig for Drv2605Lra {
-    const ID: u8 = 3;
-}
-impl DrvConfig for Drv2604Erm {
-    const ID: u8 = 4;
-}
-impl DrvConfig for Drv2604Lra {
-    const ID: u8 = 4;
-}
-impl DrvConfig for Drv2604lErm {
-    const ID: u8 = 6;
-}
-impl DrvConfig for Drv2604lLra {
-    const ID: u8 = 6;
-}
-impl DrvConfig for Drv2605lErm {
-    const ID: u8 = 7;
-}
-impl DrvConfig for Drv2605lLra {
-    const ID: u8 = 7;
-}
-
-pub struct Drv2605<I2C, DEV> {
-    i2c: I2C,
-    marker: core::marker::PhantomData<DEV>,
-}
-
-#[derive(Debug)]
-pub enum DrvError<E> {
-    DeviceIdError,
-    ConnectionError(E),
-    DeviceDiagError,
-    CalibrationError,
-    OTPError,
-}
-
-//todo how to implement these functions for all 2605x chips?
-impl<I2C, E> Drv2605<I2C, Drv2605Erm>
-where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-{
-    /// Selects the library the playback engine selects when the GO bit is set.
-    pub fn set_library(&mut self, value: LibrarySelection) -> Result<(), DrvError<E>> {
         let mut register = RegisterThree(self.read(Register::Register3)?);
         register.set_library_selection(value as u8);
         self.write(Register::Register3, register.0)
     }
 
-    /// Sets the waveform generation registers to the shape provided
-    pub fn set_waveform(&mut self, waveform: &[WaveformReg; 8]) -> Result<(), DrvError<E>> {
+    /// Sets up to 8 Effects to play in order when `set_go` is called. Stops
+    /// playing early if `Effect::None` is used.
+    pub fn set_rom(&mut self, roms: &[Effect; 8]) -> Result<(), DrvError> {
+        // Todo The MSB of each sequence register can implement a delay between
+        // sequence waveforms. When the MSB is high, bits [6:0] indicate the
+        // length of the wait time. The wait time for that step then becomes
+        // WAV_FRM_SEQ[6:0] × 10 ms
         let buf: [u8; 9] = [
             Register::WaveformSequence0 as u8,
-            waveform[0].0,
-            waveform[1].0,
-            waveform[2].0,
-            waveform[3].0,
-            waveform[4].0,
-            waveform[5].0,
-            waveform[6].0,
-            waveform[7].0,
+            roms[0] as u8,
+            roms[1] as u8,
+            roms[2] as u8,
+            roms[3] as u8,
+            roms[4] as u8,
+            roms[5] as u8,
+            roms[6] as u8,
+            roms[7] as u8,
         ];
         self.i2c
             .write(ADDRESS, &buf)
-            .map_err(DrvError::ConnectionError)
+            .map_err(|_| DrvError::ConnectionError)
     }
 
-    pub fn set_single_effect(&mut self, effect: Effect) -> Result<(), DrvError<E>> {
+    /// Set a single Rom to play during rom mode when `set_go` is called
+    pub fn set_rom_single(&mut self, effect: Effect) -> Result<(), DrvError> {
         let buf: [u8; 3] = [
             Register::WaveformSequence0 as u8,
             WaveformReg::new_effect(effect).0,
@@ -1125,200 +164,239 @@ where
         ];
         self.i2c
             .write(ADDRESS, &buf)
-            .map_err(DrvError::ConnectionError)
-    }
-}
-/// Operations that are valid only in Drv2605Lra state.
-impl<I2C, E> Drv2605<I2C, Drv2605Lra>
-where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-{
-    // pub fn set_open_loop(&mut self) -> Result<(), DrvError<E>> {
-    //     let mut control3 = Control3Reg(self.read(Register::Control3)?);
-    //     control3.set_lra_open_loop(true);
-    //     self.write(Register::Control3, control3.0)
-    // }
-
-    // pub fn config(&mut self) -> Result<(), DrvError<E>> {
-    //     self.check_id(Drv2605Lra::ID)?;
-
-    //     let mut feedback = FeedbackControlReg(self.read(Register::FeedbackControl)?);
-    //     feedback.set_n_erm_lra(true);
-    //     self.write(Register::FeedbackControl, feedback.0)?;
-
-    //     self.diagnostics()?;
-
-    //     self.set_standby(true)
-    // }
-}
-
-impl<DEV, I2C, E> Drv2605<I2C, DEV>
-where
-    DEV: DrvConfig,
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-{
-    fn check_id(&mut self, id: u8) -> Result<(), DrvError<E>> {
-        let reg = self.get_status()?;
-        if reg.device_id() != id {
-            return Err(DrvError::DeviceIdError);
-        }
-
-        Ok(())
+            .map_err(|_| DrvError::ConnectionError)
     }
 
-    /// Construct a driver instance, but don't do any initialization
-    pub fn new(i2c: I2C) -> Self {
-        Self {
-            i2c,
-            marker: core::marker::PhantomData,
-        }
-    }
+    /// Device accepts an analog voltage at the IN/TRIG pin until mode change or
+    /// standby. The reference voltage in standby mode is 1.8 V thus 100% is
+    /// 1.8V, 50% is .9V, 0% is 0V analogous to the duty-cycle percentage in
+    /// PWM mode
+    pub fn set_mode_analog(&mut self) -> Result<(), DrvError> {
+        self.set_open_loop(false)?;
 
-    /// Write `value` to `register`
-    fn write(&mut self, register: Register, value: u8) -> Result<(), DrvError<E>> {
-        self.i2c
-            .write(ADDRESS, &[register as u8, value])
-            .map_err(DrvError::ConnectionError)
-    }
+        let mut ctrl3 = Control3Reg(self.read(Register::Control3)?);
+        ctrl3.set_n_pwm_analog(true);
+        self.write(Register::Control3, ctrl3.0)?;
 
-    /// Read an 8-bit value from the register
-    fn read(&mut self, register: Register) -> Result<u8, DrvError<E>> {
-        let mut buf = [0u8; 1];
-        self.i2c
-            .write_read(ADDRESS, &[register as u8], &mut buf)
-            .map_err(DrvError::ConnectionError)?;
-        Ok(buf[0])
-    }
-
-    pub fn get_status(&mut self) -> Result<StatusReg, DrvError<E>> {
-        self.read(Register::Status).map(StatusReg)
-    }
-
-    pub fn get_mode(&mut self) -> Result<ModeReg, DrvError<E>> {
-        self.read(Register::Mode).map(ModeReg)
-    }
-
-    /// performs the equivalent operation of power
-    /// cycling the device. Any playback operations are immediately interrupted,
-    /// and all registers are reset to the default values.
-    pub fn reset(&mut self) -> Result<(), DrvError<E>> {
-        let mut mode = ModeReg(0);
-        mode.set_dev_reset(true);
-        self.write(Register::Mode, mode.0)
-    }
-
-    /// Put the device into standby mode, or wake it up from standby
-    pub fn set_standby(&mut self, standby: bool) -> Result<(), DrvError<E>> {
         let mut mode = ModeReg(self.read(Register::Mode)?);
-        mode.set_standby(standby);
+        mode.set_mode(Mode::PwmInputAndAnalogInput as u8);
         self.write(Register::Mode, mode.0)
     }
 
-    /// This field is the entry point for real-time playback (RTP) data. The DRV2605
-    /// playback engine drives the RTP_INPUT[7:0] value to the load when
-    /// MODE[2:0] = 5 (RTP mode). The RTP_INPUT[7:0] value can be updated in
-    /// real-time by the host controller to create haptic waveforms. The
-    /// RTP_INPUT[7:0] value is interpreted as signed by default, but can be set to
-    /// unsigned by the DATA_FORMAT_RTP bit in register 0x1D. When the
-    /// haptic waveform is complete, the user can idle the device by setting
-    /// MODE[2:0] = 0, or alternatively by setting STANDBY = 1.
-    pub fn set_realtime_playback_input(&mut self, value: i8) -> Result<(), DrvError<E>> {
-        self.write(Register::RealTimePlaybackInput, value as u8)
+    /// Device accepts PWM data at the IN/TRIG pin
+    pub fn set_mode_pwm(&mut self) -> Result<(), DrvError> {
+        self.set_open_loop(false)?;
+
+        let mut ctrl3 = Control3Reg(self.read(Register::Control3)?);
+        ctrl3.set_n_pwm_analog(false);
+        self.write(Register::Control3, ctrl3.0)?;
+
+        let mut mode = ModeReg(self.read(Register::Mode)?);
+        mode.set_mode(Mode::PwmInputAndAnalogInput as u8);
+        self.write(Register::Mode, mode.0)
     }
 
-    /// This bit sets the output driver into a true high-impedance state. The device
-    /// must be enabled to go into the high-impedance state. When in hardware
-    /// shutdown or standby mode, the output drivers have 15 kΩ to ground. When
-    /// the HI_Z bit is asserted, the hi-Z functionality takes effect immediately, even
-    /// if a transaction is taking place.
-    pub fn set_high_impedance_state(&mut self, value: bool) -> Result<(), DrvError<E>> {
-        let mut register = RegisterThree(self.read(Register::Register3)?);
-        register.set_hi_z(value);
-        self.write(Register::Register3, register.0)
+    /// Plays duty cycle set with `set_rtp` until another call to `set_rtp`, or
+    /// mode change
+    pub fn set_mode_rtp(&mut self) -> Result<(), DrvError> {
+        self.set_open_loop(false)?;
+
+        let mut ctrl3 = Control3Reg(self.read(Register::Control3)?);
+        // unsigned. todo do we need to unset?
+        ctrl3.set_data_format_rtp(true);
+        self.write(Register::Control3, ctrl3.0)?;
+
+        let mut mode = ModeReg(self.read(Register::Mode)?);
+        mode.set_mode(Mode::RealTimePlayback as u8);
+        self.write(Register::Mode, mode.0)
     }
 
-    /// This bit is used to fire processes in the DRV2605 device. The process
-    /// fired by the GO bit is selected by the MODE[2:0] bit (register 0x01). The
-    /// primary function of this bit is to fire playback of the waveform identifiers in
-    /// the waveform sequencer (registers 0x04 to 0x0B), in which case, this bit
-    /// can be thought of a software trigger for haptic waveforms. The GO bit
-    /// remains high until the playback of the haptic waveform sequence is
-    /// complete. Clearing the GO bit during waveform playback cancels the
-    /// waveform sequence. Using one of the external trigger modes can cause
-    /// the GO bit to be set or cleared by the external trigger pin. This bit can also
-    /// be used to fire the auto-calibration process or the diagnostic process.
-    pub fn set_go(&mut self, go: bool) -> Result<(), DrvError<E>> {
+    /// Change the duty cycle for rtp mode
+    pub fn set_rtp(&mut self, duty: u8) -> Result<(), DrvError> {
+        self.write(Register::RealTimePlaybackInput, duty)
+    }
+
+    /// Get the current rtp duty cycle
+    pub fn rtp(&mut self) -> Result<u8, DrvError> {
+        self.read(Register::RealTimePlaybackInput)
+    }
+
+    /// Trigger a GO for whatever mode is enabled
+    pub fn set_go(&mut self, go: bool) -> Result<(), DrvError> {
         let mut register = GoReg(self.read(Register::Go)?);
         register.set_go(go);
         self.write(Register::Go, register.0)
     }
 
+    /// Get the go bit. For some modes the go bit can be polled to see when it
+    /// clears indicating a waveform has completed playback.
+    pub fn go(&mut self) -> Result<bool, DrvError> {
+        Ok(GoReg(self.read(Register::Go)?).go())
+    }
+
+    /// Enabling standby goes into a low power state but maintains all mode
+    /// configuration
+    pub fn set_standby(&mut self, enable: bool) -> Result<(), DrvError> {
+        let mut mode = ModeReg(self.read(Register::Mode)?);
+        mode.set_standby(enable);
+        self.write(Register::Mode, mode.0)
+    }
+
+    /// Get the status bits
+    pub fn status(&mut self) -> Result<StatusReg, DrvError> {
+        self.read(Register::Status).map(StatusReg)
+    }
+
+    /// Get the LoadParams that were loaded at startup or calculated via
+    /// Calibration
+    pub fn calibration(&mut self) -> Result<LoadParams, DrvError> {
+        let feedback = self
+            .read(Register::FeedbackControl)
+            .map(FeedbackControlReg)?;
+
+        let comp = self.read(Register::AutoCalibrationCompensationResult)?;
+        let bemf = self.read(Register::AutoCalibrationBackEMFResult)?;
+
+        Ok(LoadParams {
+            gain: feedback.bemf_gain(),
+            comp,
+            bemf,
+        })
+    }
+
+    /* Private calls */
+
+    /// Closed-loop operation is usually desired for because of automatic
+    /// overdrive and braking properties.
+    fn set_open_loop(&mut self, enable: bool) -> Result<(), DrvError> {
+        let mut reg = Control3Reg(self.read(Register::Control3)?);
+        if self.lra {
+            reg.set_lra_open_loop(enable);
+        } else {
+            reg.set_erm_open_loop(enable);
+        }
+        self.write(Register::Control3, reg.0)
+    }
+
+    /// Write `value` to `register`
+    fn write(&mut self, register: Register, value: u8) -> Result<(), DrvError> {
+        self.i2c
+            .write(ADDRESS, &[register as u8, value])
+            .map_err(|_| DrvError::ConnectionError)
+    }
+
+    /// Read an 8-bit value from the register
+    fn read(&mut self, register: Register) -> Result<u8, DrvError> {
+        let mut buf = [0u8; 1];
+        self.i2c
+            .write_read(ADDRESS, &[register as u8], &mut buf)
+            .map_err(|_| DrvError::ConnectionError)?;
+        Ok(buf[0])
+    }
+
+    fn check_id(&mut self, id: u8) -> Result<(), DrvError> {
+        let reg = self.status()?;
+        if reg.device_id() != id {
+            return Err(DrvError::WrongDeviceId);
+        }
+
+        Ok(())
+    }
+
+    fn mode(&mut self) -> Result<ModeReg, DrvError> {
+        self.read(Register::Mode).map(ModeReg)
+    }
+
+    /// performs the equivalent operation of power cycling the device. Any
+    /// playback operations are immediately interrupted, and all registers are
+    /// reset to the default values.
+    fn reset(&mut self) -> Result<(), DrvError> {
+        let mut mode = ModeReg::default();
+        mode.set_dev_reset(true);
+        self.write(Register::Mode, mode.0)?;
+
+        while ModeReg(self.read(Register::Mode)?).dev_reset() {}
+
+        Ok(())
+    }
+
+    /// This bit sets the output driver into a true high-impedance state. The
+    /// device must be enabled to go into the high-impedance state. When in
+    /// hardware shutdown or standby mode, the output drivers have 15 kΩ to
+    /// ground. When the HI_Z bit is asserted, the hi-Z functionality takes
+    /// effect immediately, even if a transaction is taking place.
+    fn set_high_impedance_state(&mut self, value: bool) -> Result<(), DrvError> {
+        let mut register = RegisterThree(self.read(Register::Register3)?);
+        register.set_hi_z(value);
+        self.write(Register::Register3, register.0)
+    }
+
     /// This bit adds a time offset to the overdrive portion of the library
     /// waveforms. Some motors require more overdrive time than others, so this
-    /// register allows the user to add or remove overdrive time from the library
-    /// waveforms. The maximum voltage value in the library waveform is
-    /// automatically determined to be the overdrive portion. This register is only
-    /// useful in open-loop mode. Overdrive is automatic for closed-loop mode.
-    /// The offset is interpreted as 2s complement, so the time offset may be
-    /// positive or negative.
-    /// Overdrive Time Offset (ms) = ODT[7:0] × PLAYBACK_INTERVAL
-    /// See the section for PLAYBACK_INTERVAL details.
-    pub fn set_overdrive_time_offset(&mut self, value: i8) -> Result<(), DrvError<E>> {
+    /// register allows the user to add or remove overdrive time from the
+    /// library waveforms. The maximum voltage value in the library waveform is
+    /// automatically determined to be the overdrive portion. This register is
+    /// only useful in open-loop mode. Overdrive is automatic for closed-loop
+    /// mode. The offset is interpreted as 2s complement, so the time offset may
+    /// be positive or negative. Overdrive Time Offset (ms) = ODT[7:0] ×
+    /// PLAYBACK_INTERVAL See the section for PLAYBACK_INTERVAL details.
+    fn set_overdrive_time_offset(&mut self, value: i8) -> Result<(), DrvError> {
         self.write(Register::OverdriveTimeOffset, value as u8)
     }
 
-    /// This bit adds a time offset to the positive sustain portion of the library
-    /// waveforms. Some motors have a faster or slower response time than
-    /// others, so this register allows the user to add or remove positive sustain
-    /// time from the library waveforms. Any positive voltage value other than the
-    /// overdrive portion is considered as a sustain positive value. The offset is
-    /// interpreted as 2s complement, so the time offset can positive or negative.
-    /// Sustain-Time Positive Offset (ms) = SPT[7:0] × PLAYBACK_INTERVAL
-    /// See the section for PLAYBACK_INTERVAL details.
-    pub fn set_sustain_time_offset_positive(&mut self, value: i8) -> Result<(), DrvError<E>> {
+    /// This bit adds a time offset to the positive sustain portion of the
+    /// library waveforms. Some motors have a faster or slower response time
+    /// than others, so this register allows the user to add or remove positive
+    /// sustain time from the library waveforms. Any positive voltage value
+    /// other than the overdrive portion is considered as a sustain positive
+    /// value. The offset is interpreted as 2s complement, so the time offset
+    /// can positive or negative. Sustain-Time Positive Offset (ms) = SPT[7:0] ×
+    /// PLAYBACK_INTERVAL See the section for PLAYBACK_INTERVAL details.
+    fn set_sustain_time_offset_positive(&mut self, value: i8) -> Result<(), DrvError> {
         self.write(Register::SustainTimeOffsetPositive, value as u8)
     }
 
-    /// This bit adds a time offset to the negative sustain portion of the library
-    /// waveforms. Some motors have a faster or slower response time than
-    /// others, so this register allows the user to add or remove negative sustain
-    /// time from the library waveforms. Any negative voltage value other than the
-    /// overdrive portion is considered as a sustaining negative value. The offset is
-    /// interpreted as two’s complement, so the time offset can be positive or
-    /// negative.
-    /// Sustain-Time Negative Offset (ms) = SNT[7:0] × PLAYBACK_INTERVAL
-    /// See the section for PLAYBACK_INTERVAL details.
-    pub fn set_sustain_time_offset_negative(&mut self, value: i8) -> Result<(), DrvError<E>> {
+    /// This bit adds a time offset to the negative sustain portion of the
+    /// library waveforms. Some motors have a faster or slower response time
+    /// than others, so this register allows the user to add or remove negative
+    /// sustain time from the library waveforms. Any negative voltage value
+    /// other than the overdrive portion is considered as a sustaining negative
+    /// value. The offset is interpreted as two’s complement, so the time offset
+    /// can be positive or negative. Sustain-Time Negative Offset (ms) =
+    /// SNT[7:0] × PLAYBACK_INTERVAL See the section for PLAYBACK_INTERVAL
+    /// details.
+    fn set_sustain_time_offset_negative(&mut self, value: i8) -> Result<(), DrvError> {
         self.write(Register::SustainTimeOffsetNegative, value as u8)
     }
 
-    /// This bit adds a time offset to the braking portion of the library waveforms.
-    /// Some motors require more braking time than others, so this register allows
-    /// the user to add or take away brake time from the library waveforms. The
-    /// most negative voltage value in the library waveform is automatically
-    /// determined to be the braking portion. This register is only useful in open-loop
-    /// mode. Braking is automatic for closed-loop mode. The offset is interpreted as
-    /// 2s complement, so the time offset can be positive or negative.
-    /// Brake Time Offset (ms) = BRT[7:0] × PLAYBACK_INTERVAL
-    /// See the section for PLAYBACK_INTERVAL details.
-    pub fn set_brake_time_offset(&mut self, value: i8) -> Result<(), DrvError<E>> {
+    /// This bit adds a time offset to the braking portion of the library
+    /// waveforms. Some motors require more braking time than others, so this
+    /// register allows the user to add or take away brake time from the library
+    /// waveforms. The most negative voltage value in the library waveform is
+    /// automatically determined to be the braking portion. This register is
+    /// only useful in open-loop mode. Braking is automatic for closed-loop
+    /// mode. The offset is interpreted as 2s complement, so the time offset can
+    /// be positive or negative. Brake Time Offset (ms) = BRT[7:0] ×
+    /// PLAYBACK_INTERVAL See the section for PLAYBACK_INTERVAL details.
+    fn set_brake_time_offset(&mut self, value: i8) -> Result<(), DrvError> {
         self.write(Register::BrakeTimeOffset, value as u8)
     }
 
-    pub fn load_calibration(&mut self, comp: u8, bemf: u8, gain: u8) -> Result<(), DrvError<E>> {
+    fn set_calibration(&mut self, load: LoadParams) -> Result<(), DrvError> {
         let mut fbcr = FeedbackControlReg(self.read(Register::FeedbackControl)?);
-        fbcr.set_bemf_gain(gain);
-        self.write(Register::AutoCalibrationCompensationResult, fbcr.0)?;
+        fbcr.set_bemf_gain(load.gain);
+        self.write(Register::FeedbackControl, fbcr.0)?;
 
-        self.write(Register::AutoCalibrationCompensationResult, comp)?;
+        self.write(Register::AutoCalibrationCompensationResult, load.comp)?;
 
-        self.write(Register::AutoCalibrationBackEMFResult, bemf)
+        self.write(Register::AutoCalibrationBackEMFResult, load.bemf)
     }
 
-    pub fn diagnostics(&mut self) -> Result<(), DrvError<E>> {
+    /// Run diagnostics
+    fn diagnostics(&mut self) -> Result<(), DrvError> {
         let mut mode = ModeReg(self.read(Register::Mode)?);
         mode.set_standby(false);
-        mode.set_mode(6);
+        mode.set_mode(Mode::Diagnostics as u8);
         self.write(Register::Mode, mode.0)?;
 
         self.set_go(true)?;
@@ -1326,18 +404,20 @@ where
         //todo timeout
         while GoReg(self.read(Register::Go)?).go() {}
 
-        let reg = self.get_status()?;
+        let reg = self.status()?;
         if reg.diagnostic_result() {
-            return Err(DrvError::DeviceDiagError);
+            return Err(DrvError::DeviceDiagnosticFailed);
         }
 
         Ok(())
     }
 
-    pub fn calibrate(&mut self) -> Result<(), DrvError<E>> {
+    /// Run auto calibration which updates the calibration registers and returns
+    /// the resulting LoadParams
+    fn calibrate(&mut self) -> Result<LoadParams, DrvError> {
         let mut mode = ModeReg(self.read(Register::Mode)?);
         mode.set_standby(false);
-        mode.set_mode(7);
+        mode.set_mode(Mode::AutoCalibration as u8);
         self.write(Register::Mode, mode.0)?;
 
         self.set_go(true)?;
@@ -1345,11 +425,137 @@ where
         //todo timeout
         while GoReg(self.read(Register::Go)?).go() {}
 
-        let reg = self.get_status()?;
+        let reg = self.status()?;
         if reg.diagnostic_result() {
-            return Err(DrvError::DeviceDiagError);
+            return Err(DrvError::CalibrationFailed);
         }
 
-        Ok(())
+        self.calibration()
+    }
+
+    /// Check if the device's OTP has been set
+    fn is_otp(&mut self) -> Result<bool, DrvError> {
+        let reg4 = Control4Reg(self.read(Register::Control4)?);
+        Ok(reg4.otp_status())
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug)]
+pub enum DrvError {
+    WrongDeviceId,
+    ConnectionError,
+    DeviceDiagnosticFailed,
+    CalibrationFailed,
+    OTPNotProgrammed,
+    WrongCalibrationEnum,
+}
+
+/// The hardcoded address of the driver.  All drivers share the same address so
+/// that it is possible to broadcast on the bus and have multiple units emit the
+/// same waveform
+pub const ADDRESS: u8 = 0x5a;
+
+#[allow(unused)]
+pub enum LraCalibration {
+    Otp,
+    /// When using autocalibration be sure to secure the motor to mass. It can't
+    /// calibrate if its jumping around on a board or a desk.
+    Auto(GeneralParams, LraParams),
+    Load(LoadParams),
+}
+
+#[allow(unused)]
+pub enum ErmCalibration {
+    Otp,
+    /// When using autocalibration be sure to secure the motor to mass. It can't
+    /// calibrate if its jumping around on a board or a desk.
+    Auto(GeneralParams),
+    Load(LoadParams),
+}
+pub struct LoadParams {
+    pub comp: u8,
+    pub bemf: u8,
+    pub gain: u8,
+}
+
+pub struct GeneralParams {
+    pub brake_factor: u8,
+    pub loop_gain: u8,
+    pub lra_sample_time: u8,
+    pub lra_blanking_time: u8,
+    pub lra_idiss_time: u8,
+    pub auto_cal_time: u8,
+    pub lra_zc_det_time: u8,
+}
+
+/// additional fields requited for LRA calibration
+pub struct LraParams {
+    pub rated: u8,
+    pub clamp: u8,
+    pub drive_time: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ErmLibrary {
+    Empty = 0,
+    /// Rated Voltage 1.3V Overdrive Voltage 3V Rise Time 40-60ms Brake Time 20-40ms
+    A = 1,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 40-60ms Brake Time 5-15ms
+    B = 2,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 60-80ms Brake Time 10-20ms
+    C = 3,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 100-140ms Brake Time 15-25ms
+    D = 4,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time >140ms Brake Time >30ms
+    E = 5,
+    /// Rated Voltage 4.5V Overdrive Voltage 5V Rise Time 35-45ms Brake Time 10-20ms
+    F = 7,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LraLibrary {
+    Empty = 0,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time >140ms Brake Time >30ms
+    Lra = 6,
+}
+
+impl From<u8> for LraLibrary {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Empty,
+            6 => Self::Lra,
+            _ => unreachable!("impossible LibrarySelection value"),
+        }
+    }
+}
+
+impl From<u8> for ErmLibrary {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Empty,
+            1 => Self::A,
+            2 => Self::B,
+            3 => Self::C,
+            4 => Self::D,
+            5 => Self::E,
+            7 => Self::F,
+            _ => unreachable!("impossible LibrarySelection value"),
+        }
+    }
+}
+
+impl Default for GeneralParams {
+    /// general best fit values from datasheet
+    fn default() -> Self {
+        Self {
+            brake_factor: 2,
+            loop_gain: 2,
+            lra_sample_time: 3,
+            lra_blanking_time: 1, //not on drv2605
+            lra_idiss_time: 1,    //not on drv2605
+            auto_cal_time: 3,
+            lra_zc_det_time: 0, //not on drv2605
+        }
     }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -114,7 +114,7 @@ pub struct RatedVoltageReg(pub u8);
 
 impl Default for RatedVoltageReg {
     fn default() -> Self {
-        Self(0x3f)
+        Self(0x3E)
     }
 }
 
@@ -123,7 +123,7 @@ pub struct OverdriveClampReg(pub u8);
 
 impl Default for OverdriveClampReg {
     fn default() -> Self {
-        Self(0x89)
+        Self(0x8C)
     }
 }
 
@@ -132,7 +132,7 @@ pub struct AutoCalibrationCompensationReg(pub u8);
 
 impl Default for AutoCalibrationCompensationReg {
     fn default() -> Self {
-        Self(0x0D)
+        Self(0x0C)
     }
 }
 
@@ -141,7 +141,7 @@ pub struct AutoCalibrationCompensationBackEmfReg(pub u8);
 
 impl Default for AutoCalibrationCompensationBackEmfReg {
     fn default() -> Self {
-        Self(0x6D)
+        Self(0x6C)
     }
 }
 
@@ -192,7 +192,7 @@ impl From<u8> for Library {
 }
 
 bitfield! {
-    pub struct RegisterThree(u8);
+    pub struct LibrarySelectionReg(u8);
     impl Debug;
     /// This bit sets the output driver into a true high-impedance state. The device
     /// must be enabled to go into the high-impedance state. When in hardware
@@ -802,8 +802,8 @@ impl Default for Control4Reg {
 #[derive(Copy, Clone)]
 #[repr(u8)]
 pub enum Register {
-    Status = 0,
-    Mode = 1,
+    Status = 0x00,
+    Mode = 0x01,
     /// This field is the entry point for real-time playback (RTP) data. The
     /// DRV2605 playback engine drives the RTP_INPUT[7:0] value to the load when
     /// MODE[2:0] = 5 (RTP mode). The RTP_INPUT[7:0] value can be updated in
@@ -812,21 +812,28 @@ pub enum Register {
     /// to unsigned by the DATA_FORMAT_RTP bit in register 0x1D. When the haptic
     /// waveform is complete, the user can idle the device by setting MODE[2:0]
     /// = 0, or alternatively by setting STANDBY = 1.
-    RealTimePlaybackInput = 2,
-    Register3 = 3,
-    WaveformSequence0 = 4,
-    WaveformSequence1 = 5,
-    WaveformSequence2 = 6,
-    WaveformSequence3 = 7,
-    WaveformSequence4 = 8,
-    WaveformSequence5 = 9,
-    WaveformSequence6 = 0xa,
-    WaveformSequence7 = 0xb,
-    Go = 0xc,
-    OverdriveTimeOffset = 0xd,
-    SustainTimeOffsetPositive = 0xe,
-    SustainTimeOffsetNegative = 0xf,
+    RealTimePlaybackInput = 0x02,
+    LibrarySelection = 0x03,
+    WaveformSequence0 = 0x04,
+    WaveformSequence1 = 0x05,
+    WaveformSequence2 = 0x06,
+    WaveformSequence3 = 0x07,
+    WaveformSequence4 = 0x08,
+    WaveformSequence5 = 0x09,
+    WaveformSequence6 = 0x0a,
+    WaveformSequence7 = 0x0b,
+    Go = 0x0c,
+    OverdriveTimeOffset = 0x0d,
+    SustainTimeOffsetPositive = 0x0e,
+    SustainTimeOffsetNegative = 0x0f,
     BrakeTimeOffset = 0x10,
+
+    // todo
+    AudioToVibeControl = 0x11,
+    AudioToVibeMinimumInputLevel = 0x12,
+    AudioToVibeMaximumInputLevel = 0x13,
+    AudioToVibeMinimumOutputDrive = 0x14,
+    AudioToVibeMaximumOutputDrive = 0x15,
 
     /// This bit sets the reference voltage for full-scale output during
     /// closed-loop operation. The auto-calibration routine uses this register
@@ -874,8 +881,6 @@ pub enum Register {
     /// BEMF_GAIN[1:0]
     AutoCalibrationBackEMFResult = 0x19,
 
-    LRAOpenLoopPeriod = 0x20,
-
     FeedbackControl = 0x1a,
 
     Control1 = 0x1b,
@@ -885,4 +890,10 @@ pub enum Register {
 
     // todo
     Control5 = 0x1f,
+
+    LRAOpenLoopPeriod = 0x20,
+
+    //todo
+    VBatVoltageMonitor = 0x21,
+    LraResonancePeriod = 0x22,
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -206,259 +206,393 @@ bitfield! {
     pub into Library, library_selection, set_library_selection: 2, 0;
 }
 
+impl From<Effect> for u8 {
+    fn from(val: Effect) -> Self {
+        match val {
+            Effect::Delays(n) => n & 0x80,
+            Effect::Stop => 0,
+            Effect::StrongClick100 => 1,
+            Effect::StrongClick60 => 2,
+            Effect::StrongClick30 => 3,
+            Effect::SharpClick100 => 4,
+            Effect::SharpClick60 => 5,
+            Effect::SharpClick30 => 6,
+            Effect::SoftBump100 => 7,
+            Effect::SoftBump60 => 8,
+            Effect::SoftBump30 => 9,
+            Effect::DoubleClick100 => 10,
+            Effect::DoubleClick60 => 11,
+            Effect::TripleClick100 => 12,
+            Effect::SoftFuzz60 => 13,
+            Effect::StrongBuzz100 => 14,
+            Effect::Alert750ms => 15,
+            Effect::Alert1000ms => 16,
+            Effect::StrongClickOne100 => 17,
+            Effect::StrongClickTwo80 => 18,
+            Effect::StrongClickThree60 => 19,
+            Effect::StrongClickFour30 => 20,
+            Effect::MediumClickOne100 => 21,
+            Effect::MediumClickTwo80 => 22,
+            Effect::MediumClickThree60 => 23,
+            Effect::SharpTickOne100 => 24,
+            Effect::SharpTickTwo80 => 25,
+            Effect::SharpTickThree60 => 26,
+            Effect::ShortDoubleClickStrongOne100 => 27,
+            Effect::ShortDoubleClickStrongTwo80 => 28,
+            Effect::ShortDoubleClickStrongThree60 => 29,
+            Effect::ShortDoubleClickStrongFour30 => 30,
+            Effect::ShortDoubleClickMediumOne100 => 31,
+            Effect::ShortDoubleClickMediumTwo80 => 32,
+            Effect::ShortDoubleClickMediumThree60 => 33,
+            Effect::ShortDoubleSharpTickOne100 => 34,
+            Effect::ShortDoubleSharpTickTwo80 => 35,
+            Effect::ShortDoubleSharpTickThree60 => 36,
+            Effect::LongDoubleSharpClickStrongOne100 => 37,
+            Effect::LongDoubleSharpClickStrongTwo80 => 38,
+            Effect::LongDoubleSharpClickStrongThree60 => 39,
+            Effect::LongDoubleSharpClickStrongFour30 => 40,
+            Effect::LongDoubleSharpClickMediumOne100 => 41,
+            Effect::LongDoubleSharpClickMediumTwo80 => 42,
+            Effect::LongDoubleSharpClickMediumThree60 => 43,
+            Effect::LongDoubleSharpTickOne100 => 44,
+            Effect::LongDoubleSharpTickTwo80 => 45,
+            Effect::LongDoubleSharpTickThree60 => 46,
+            Effect::BuzzOne100 => 47,
+            Effect::BuzzTwo80 => 48,
+            Effect::BuzzThree60 => 49,
+            Effect::BuzzFour40 => 50,
+            Effect::BuzzFive20 => 51,
+            Effect::PulsingStrongOne100 => 52,
+            Effect::PulsingStrongTwo60 => 53,
+            Effect::PulsingMediumOne100 => 54,
+            Effect::PulsingMediumTwo60 => 55,
+            Effect::PulsingSharpOne100 => 56,
+            Effect::PulsingSharpTwo60 => 57,
+            Effect::TransitionClickOne100 => 58,
+            Effect::TransitionClickTwo80 => 59,
+            Effect::TransitionClickThree60 => 60,
+            Effect::TransitionClickFour40 => 61,
+            Effect::TransitionClickFive20 => 62,
+            Effect::TransitionClickSix10 => 63,
+            Effect::TransitionHumOne100 => 64,
+            Effect::TransitionHumTwo80 => 65,
+            Effect::TransitionHumThree60 => 66,
+            Effect::TransitionHumFour40 => 67,
+            Effect::TransitionHumFive20 => 68,
+            Effect::TransitionHumSix10 => 69,
+            Effect::TransitionRampDownLongSmoothOne100to0 => 70,
+            Effect::TransitionRampDownLongSmoothTwo100to0 => 71,
+            Effect::TransitionRampDownMediumSmoothOne100to0 => 72,
+            Effect::TransitionRampDownMediumSmoothTwo100to0 => 73,
+            Effect::TransitionRampDownShortSmoothOne100to0 => 74,
+            Effect::TransitionRampDownShortSmoothTwo100to0 => 75,
+            Effect::TransitionRampDownLongSharpOne100to0 => 76,
+            Effect::TransitionRampDownLongSharpTwo100to0 => 77,
+            Effect::TransitionRampDownMediumSharpOne100to0 => 78,
+            Effect::TransitionRampDownMediumSharpTwo100to0 => 79,
+            Effect::TransitionRampDownShortSharpOne100to0 => 80,
+            Effect::TransitionRampDownShortSharpTwo100to0 => 81,
+            Effect::TransitionRampUpLongSmoothOne0to100 => 82,
+            Effect::TransitionRampUpLongSmoothTwo0to100 => 83,
+            Effect::TransitionRampUpMediumSmoothOne0to100 => 84,
+            Effect::TransitionRampUpMediumSmoothTwo0to100 => 85,
+            Effect::TransitionRampUpShortSmoothOne0to100 => 86,
+            Effect::TransitionRampUpShortSmoothTwo0to100 => 87,
+            Effect::TransitionRampUpLongSharpOne0to100 => 88,
+            Effect::TransitionRampUpLongSharpTwo0to100 => 89,
+            Effect::TransitionRampUpMediumSharpOne0to100 => 90,
+            Effect::TransitionRampUpMediumSharpTwo0to100 => 91,
+            Effect::TransitionRampUpShortSharpOne0to100 => 92,
+            Effect::TransitionRampUpShortSharpTwo0to100 => 93,
+            Effect::TransitionRampDownLongSmoothOne50to0 => 94,
+            Effect::TransitionRampDownLongSmoothTwo50to0 => 95,
+            Effect::TransitionRampDownMediumSmoothOne50to0 => 96,
+            Effect::TransitionRampDownMediumSmoothTwo50to0 => 97,
+            Effect::TransitionRampDownShortSmoothOne50to0 => 98,
+            Effect::TransitionRampDownShortSmoothTwo50to0 => 99,
+            Effect::TransitionRampDownLongSharpOne50to0 => 100,
+            Effect::TransitionRampDownLongSharpTwo50to0 => 101,
+            Effect::TransitionRampDownMediumSharpOne50to0 => 102,
+            Effect::TransitionRampDownMediumSharpTwo50to0 => 103,
+            Effect::TransitionRampDownShortSharpOne50to0 => 104,
+            Effect::TransitionRampDownShortSharpTwo50to0 => 105,
+            Effect::TransitionRampUpLongSmoothOne0to50 => 106,
+            Effect::TransitionRampUpLongSmoothTwo0to50 => 107,
+            Effect::TransitionRampUpMediumSmoothOne0to50 => 108,
+            Effect::TransitionRampUpMediumSmoothTwo0to50 => 109,
+            Effect::TransitionRampUpShortSmoothOne0to50 => 110,
+            Effect::TransitionRampUpShortSmoothTwo0to50 => 111,
+            Effect::TransitionRampUpLongSharpOne0to50 => 112,
+            Effect::TransitionRampUpLongSharpTwo0to50 => 113,
+            Effect::TransitionRampUpMediumSharpOne0to50 => 114,
+            Effect::TransitionRampUpMediumSharpTwo0to50 => 115,
+            Effect::TransitionRampUpShortSharpOne0to50 => 116,
+            Effect::TransitionRampUpShortSharpTwo0to50 => 117,
+            Effect::LongBuzzForProgrammaticStopping100 => 118,
+            Effect::SmoothHumOne50 => 119,
+            Effect::SmoothHumTwo40 => 120,
+            Effect::SmoothHumThree30 => 121,
+            Effect::SmoothHumFour20 => 122,
+            Effect::SmoothHumFive10 => 123,
+        }
+    }
+}
+
 /// Identifies which of the waveforms from the ROM library that should
 /// be played in a given waveform slot.
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub enum Effect {
-    /// No effect
-    None = 0,
+    /// No effect, or Stop playing
+    Stop,
+    /// Use the effect period as (up to 127) counts of 10ms delays
+    Delays(u8),
     /// Strong Click - 100%
-    StrongClick100 = 1,
+    StrongClick100,
     /// Strong Click - 60%
-    StrongClick60 = 2,
+    StrongClick60,
     /// Strong Click - 30%
-    StrongClick30 = 3,
+    StrongClick30,
     /// Sharp Click - 100%
-    SharpClick100 = 4,
+    SharpClick100,
     /// Sharp Click - 60%
-    SharpClick60 = 5,
+    SharpClick60,
     /// Sharp Click - 30%
-    SharpClick30 = 6,
+    SharpClick30,
     /// Soft Bump - 100%
-    SoftBump100 = 7,
+    SoftBump100,
     /// Soft Bump - 60%
-    SoftBump60 = 8,
+    SoftBump60,
     /// Soft Bump - 30%
-    SoftBump30 = 9,
+    SoftBump30,
     /// Double Click - 100%
-    DoubleClick100 = 10,
+    DoubleClick100,
     /// Double Click - 60%
-    DoubleClick60 = 11,
+    DoubleClick60,
     /// Triple Click - 100%
-    TripleClick100 = 12,
+    TripleClick100,
     /// Soft Fuzz - 60%
-    SoftFuzz60 = 13,
+    SoftFuzz60,
     /// Strong Buzz - 100%
-    StrongBuzz100 = 14,
+    StrongBuzz100,
     /// 750 ms Alert 100%
-    Alert750ms = 15,
+    Alert750ms,
     /// 1000 ms Alert 100%
-    Alert1000ms = 16,
+    Alert1000ms,
     /// Strong Click 1 - 100%
-    StrongClickOne100 = 17,
+    StrongClickOne100,
     /// Strong Click 2 - 80%
-    StrongClickTwo80 = 18,
+    StrongClickTwo80,
     /// Strong Click 3 - 60%
-    StrongClickThree60 = 19,
+    StrongClickThree60,
     /// Strong Click 4 - 30%
-    StrongClickFour30 = 20,
+    StrongClickFour30,
     /// Medium Click 1 - 100%
-    MediumClickOne100 = 21,
+    MediumClickOne100,
     /// Medium Click 2 - 80%
-    MediumClickTwo80 = 22,
+    MediumClickTwo80,
     /// Medium Click 3 - 60%
-    MediumClickThree60 = 23,
+    MediumClickThree60,
     /// Sharp Tick 1 - 100%
-    SharpTickOne100 = 24,
+    SharpTickOne100,
     /// Sharp Tick 2 - 80%
-    SharpTickTwo80 = 25,
+    SharpTickTwo80,
     /// Sharp Tick 3 - 60%
-    SharpTickThree60 = 26,
+    SharpTickThree60,
     /// Short Double Click Strong 1 - 100%
-    ShortDoubleClickStrongOne100 = 27,
+    ShortDoubleClickStrongOne100,
     /// Short Double Click Strong 2 - 80%
-    ShortDoubleClickStrongTwo80 = 28,
+    ShortDoubleClickStrongTwo80,
     /// Short Double Click Strong 3 - 60%
-    ShortDoubleClickStrongThree60 = 29,
+    ShortDoubleClickStrongThree60,
     /// Short Double Click Strong 4 - 30%
-    ShortDoubleClickStrongFour30 = 30,
+    ShortDoubleClickStrongFour30,
     /// Short Double Click Medium 1 - 100%
-    ShortDoubleClickMediumOne100 = 31,
+    ShortDoubleClickMediumOne100,
     /// Short Double Click Medium 2 - 80%
-    ShortDoubleClickMediumTwo80 = 32,
+    ShortDoubleClickMediumTwo80,
     /// Short Double Click Medium 3 - 60%
-    ShortDoubleClickMediumThree60 = 33,
+    ShortDoubleClickMediumThree60,
     /// Short Double Sharp Tick 1 - 100%
-    ShortDoubleSharpTickOne100 = 34,
+    ShortDoubleSharpTickOne100,
     /// Short Double Sharp Tick 2 - 80%
-    ShortDoubleSharpTickTwo80 = 35,
+    ShortDoubleSharpTickTwo80,
     /// Short Double Sharp Tick 3 - 60%
-    ShortDoubleSharpTickThree60 = 36,
+    ShortDoubleSharpTickThree60,
     /// Long Double Sharp Click Strong 1 - 100%
-    LongDoubleSharpClickStrongOne100 = 37,
+    LongDoubleSharpClickStrongOne100,
     /// Long Double Sharp Click Strong 2 - 80%
-    LongDoubleSharpClickStrongTwo80 = 38,
+    LongDoubleSharpClickStrongTwo80,
     /// Long Double Sharp Click Strong 3 - 60%
-    LongDoubleSharpClickStrongThree60 = 39,
+    LongDoubleSharpClickStrongThree60,
     /// Long Double Sharp Click Strong 4 - 30%
-    LongDoubleSharpClickStrongFour30 = 40,
+    LongDoubleSharpClickStrongFour30,
     /// Long Double Sharp Click Medium 1 - 100%
-    LongDoubleSharpClickMediumOne100 = 41,
+    LongDoubleSharpClickMediumOne100,
     /// Long Double Sharp Click Medium 2 - 80%
-    LongDoubleSharpClickMediumTwo80 = 42,
+    LongDoubleSharpClickMediumTwo80,
     /// Long Double Sharp Click Medium 3 - 60%
-    LongDoubleSharpClickMediumThree60 = 43,
+    LongDoubleSharpClickMediumThree60,
     /// Long Double Sharp Tick 1 - 100%
-    LongDoubleSharpTickOne100 = 44,
+    LongDoubleSharpTickOne100,
     /// Long Double Sharp Tick 2 - 80%
-    LongDoubleSharpTickTwo80 = 45,
+    LongDoubleSharpTickTwo80,
     /// Long Double Sharp Tick 3 - 60%
-    LongDoubleSharpTickThree60 = 46,
+    LongDoubleSharpTickThree60,
     /// Buzz 1 - 100%
-    BuzzOne100 = 47,
+    BuzzOne100,
     /// Buzz 2 - 80%
-    BuzzTwo80 = 48,
+    BuzzTwo80,
     /// Buzz 3 - 60%
-    BuzzThree60 = 49,
+    BuzzThree60,
     /// Buzz 4 - 40%
-    BuzzFour40 = 50,
+    BuzzFour40,
     /// Buzz 5 - 20%
-    BuzzFive20 = 51,
+    BuzzFive20,
     /// Pulsing Strong 1 - 100%
-    PulsingStrongOne100 = 52,
+    PulsingStrongOne100,
     /// Pulsing Strong 2 - 60%
-    PulsingStrongTwo60 = 53,
+    PulsingStrongTwo60,
     /// Pulsing Medium 1 - 100%
-    PulsingMediumOne100 = 54,
+    PulsingMediumOne100,
     /// Pulsing Medium 2 - 60%
-    PulsingMediumTwo60 = 55,
+    PulsingMediumTwo60,
     /// Pulsing Sharp 1 - 100%
-    PulsingSharpOne100 = 56,
+    PulsingSharpOne100,
     /// Pulsing Sharp 2 - 60%
-    PulsingSharpTwo60 = 57,
+    PulsingSharpTwo60,
     /// Transition Click 1 - 100%
-    TransitionClickOne100 = 58,
+    TransitionClickOne100,
     /// Transition Click 2 - 80%
-    TransitionClickTwo80 = 59,
+    TransitionClickTwo80,
     /// Transition Click 3 - 60%
-    TransitionClickThree60 = 60,
+    TransitionClickThree60,
     /// Transition Click 4 - 40%
-    TransitionClickFour40 = 61,
+    TransitionClickFour40,
     /// Transition Click 5 - 20%
-    TransitionClickFive20 = 62,
+    TransitionClickFive20,
     /// Transition Click 6 - 10%
-    TransitionClickSix10 = 63,
+    TransitionClickSix10,
     /// Transition Hum 1 - 100%
-    TransitionHumOne100 = 64,
+    TransitionHumOne100,
     /// Transition Hum 2 - 80%
-    TransitionHumTwo80 = 65,
+    TransitionHumTwo80,
     /// Transition Hum 3 - 60%
-    TransitionHumThree60 = 66,
+    TransitionHumThree60,
     /// Transition Hum 4 - 40%
-    TransitionHumFour40 = 67,
+    TransitionHumFour40,
     /// Transition Hum 5 - 20%
-    TransitionHumFive20 = 68,
+    TransitionHumFive20,
     /// Transition Hum 6 - 10%
-    TransitionHumSix10 = 69,
+    TransitionHumSix10,
     /// Transition Ramp Down Long Smooth 1 - 100 to 0%
-    TransitionRampDownLongSmoothOne100to0 = 70,
+    TransitionRampDownLongSmoothOne100to0,
     /// Transition Ramp Down Long Smooth 2 - 100 to 0%
-    TransitionRampDownLongSmoothTwo100to0 = 71,
+    TransitionRampDownLongSmoothTwo100to0,
     /// Transition Ramp Down Medium Smooth 1 - 100 to 0%
-    TransitionRampDownMediumSmoothOne100to0 = 72,
+    TransitionRampDownMediumSmoothOne100to0,
     /// Transition Ramp Down Medium Smooth 2 - 100 to 0%
-    TransitionRampDownMediumSmoothTwo100to0 = 73,
+    TransitionRampDownMediumSmoothTwo100to0,
     /// Transition Ramp Down Short Smooth 1 - 100 to 0%
-    TransitionRampDownShortSmoothOne100to0 = 74,
+    TransitionRampDownShortSmoothOne100to0,
     /// Transition Ramp Down Short Smooth 2 - 100 to 0%
-    TransitionRampDownShortSmoothTwo100to0 = 75,
+    TransitionRampDownShortSmoothTwo100to0,
     /// Transition Ramp Down Long Sharp 1 - 100 to 0%
-    TransitionRampDownLongSharpOne100to0 = 76,
+    TransitionRampDownLongSharpOne100to0,
     /// Transition Ramp Down Long Sharp 2 - 100 to 0%
-    TransitionRampDownLongSharpTwo100to0 = 77,
+    TransitionRampDownLongSharpTwo100to0,
     /// Transition Ramp Down Medium Sharp 1 - 100 to 0%
-    TransitionRampDownMediumSharpOne100to0 = 78,
+    TransitionRampDownMediumSharpOne100to0,
     /// Transition Ramp Down Medium Sharp 2 - 100 to 0%
-    TransitionRampDownMediumSharpTwo100to0 = 79,
+    TransitionRampDownMediumSharpTwo100to0,
     /// Transition Ramp Down Short Sharp 1 - 100 to 0%
-    TransitionRampDownShortSharpOne100to0 = 80,
+    TransitionRampDownShortSharpOne100to0,
     /// Transition Ramp Down Short Sharp 2 - 100 to 0%
-    TransitionRampDownShortSharpTwo100to0 = 81,
+    TransitionRampDownShortSharpTwo100to0,
     /// Transition Ramp Up Long Smooth 1 - 0 to 100%
-    TransitionRampUpLongSmoothOne0to100 = 82,
+    TransitionRampUpLongSmoothOne0to100,
     /// Transition Ramp Up Long Smooth 2 - 0 to 100%
-    TransitionRampUpLongSmoothTwo0to100 = 83,
+    TransitionRampUpLongSmoothTwo0to100,
     /// Transition Ramp Up Medium Smooth 1 - 0 to 100%
-    TransitionRampUpMediumSmoothOne0to100 = 84,
+    TransitionRampUpMediumSmoothOne0to100,
     /// Transition Ramp Up Medium Smooth 2 - 0 to 100%
-    TransitionRampUpMediumSmoothTwo0to100 = 85,
+    TransitionRampUpMediumSmoothTwo0to100,
     /// Transition Ramp Up Short Smooth 1 - 0 to 100%
-    TransitionRampUpShortSmoothOne0to100 = 86,
+    TransitionRampUpShortSmoothOne0to100,
     /// Transition Ramp Up Short Smooth 2 - 0 to 100%
-    TransitionRampUpShortSmoothTwo0to100 = 87,
+    TransitionRampUpShortSmoothTwo0to100,
     /// Transition Ramp Up Long Sharp 1 - 0 to 100%
-    TransitionRampUpLongSharpOne0to100 = 88,
+    TransitionRampUpLongSharpOne0to100,
     /// Transition Ramp Up Long Sharp 2 - 0 to 100%
-    TransitionRampUpLongSharpTwo0to100 = 89,
+    TransitionRampUpLongSharpTwo0to100,
     /// Transition Ramp Up Medium Sharp 1 - 0 to 100%
-    TransitionRampUpMediumSharpOne0to100 = 90,
+    TransitionRampUpMediumSharpOne0to100,
     /// Transition Ramp Up Medium Sharp 2 - 0 to 100%
-    TransitionRampUpMediumSharpTwo0to100 = 91,
+    TransitionRampUpMediumSharpTwo0to100,
     /// Transition Ramp Up Short Sharp 1 - 0 to 100%
-    TransitionRampUpShortSharpOne0to100 = 92,
+    TransitionRampUpShortSharpOne0to100,
     /// Transition Ramp Up Short Sharp 2 - 0 to 100%
-    TransitionRampUpShortSharpTwo0to100 = 93,
+    TransitionRampUpShortSharpTwo0to100,
     /// Transition Ramp Down Long Smooth 1 - 50 to 0%
-    TransitionRampDownLongSmoothOne50to0 = 94,
+    TransitionRampDownLongSmoothOne50to0,
     /// Transition Ramp Down Long Smooth 2 - 50 to 0%
-    TransitionRampDownLongSmoothTwo50to0 = 95,
+    TransitionRampDownLongSmoothTwo50to0,
     /// Transition Ramp Down Medium Smooth 1 - 50 to 0%
-    TransitionRampDownMediumSmoothOne50to0 = 96,
+    TransitionRampDownMediumSmoothOne50to0,
     /// Transition Ramp Down Medium Smooth 2 - 50 to 0%
-    TransitionRampDownMediumSmoothTwo50to0 = 97,
+    TransitionRampDownMediumSmoothTwo50to0,
     /// Transition Ramp Down Short Smooth 1 - 50 to 0%
-    TransitionRampDownShortSmoothOne50to0 = 98,
+    TransitionRampDownShortSmoothOne50to0,
     /// Transition Ramp Down Short Smooth 2 - 50 to 0%
-    TransitionRampDownShortSmoothTwo50to0 = 99,
+    TransitionRampDownShortSmoothTwo50to0,
     /// Transition Ramp Down Long Sharp 1 - 50 to 0%
-    TransitionRampDownLongSharpOne50to0 = 100,
+    TransitionRampDownLongSharpOne50to0,
     /// Transition Ramp Down Long Sharp 2 - 50 to 0%
-    TransitionRampDownLongSharpTwo50to0 = 101,
+    TransitionRampDownLongSharpTwo50to0,
     /// Transition Ramp Down Medium Sharp 1 - 50 to 0%
-    TransitionRampDownMediumSharpOne50to0 = 102,
+    TransitionRampDownMediumSharpOne50to0,
     /// Transition Ramp Down Medium Sharp 2 - 50 to 0%
-    TransitionRampDownMediumSharpTwo50to0 = 103,
+    TransitionRampDownMediumSharpTwo50to0,
     /// Transition Ramp Down Short Sharp 1 - 50 to 0%
-    TransitionRampDownShortSharpOne50to0 = 104,
+    TransitionRampDownShortSharpOne50to0,
     /// Transition Ramp Down Short Sharp 2 - 50 to 0%
-    TransitionRampDownShortSharpTwo50to0 = 105,
+    TransitionRampDownShortSharpTwo50to0,
     /// Transition Ramp Up Long Smooth 1 - 0 to 50%
-    TransitionRampUpLongSmoothOne0to50 = 106,
+    TransitionRampUpLongSmoothOne0to50,
     /// Transition Ramp Up Long Smooth 2 - 0 to 50%
-    TransitionRampUpLongSmoothTwo0to50 = 107,
+    TransitionRampUpLongSmoothTwo0to50,
     /// Transition Ramp Up Medium Smooth 1 - 0 to 50%
-    TransitionRampUpMediumSmoothOne0to50 = 108,
+    TransitionRampUpMediumSmoothOne0to50,
     /// Transition Ramp Up Medium Smooth 2 - 0 to 50%
-    TransitionRampUpMediumSmoothTwo0to50 = 109,
+    TransitionRampUpMediumSmoothTwo0to50,
     /// Transition Ramp Up Short Smooth 1 - 0 to 50%
-    TransitionRampUpShortSmoothOne0to50 = 110,
+    TransitionRampUpShortSmoothOne0to50,
     /// Transition Ramp Up Short Smooth 2 - 0 to 50%
-    TransitionRampUpShortSmoothTwo0to50 = 111,
+    TransitionRampUpShortSmoothTwo0to50,
     /// Transition Ramp Up Long Sharp 1 - 0 to 50%
-    TransitionRampUpLongSharpOne0to50 = 112,
+    TransitionRampUpLongSharpOne0to50,
     /// Transition Ramp Up Long Sharp 2 - 0 to 50%
-    TransitionRampUpLongSharpTwo0to50 = 113,
+    TransitionRampUpLongSharpTwo0to50,
     /// Transition Ramp Up Medium Sharp 1 - 0 to 50%
-    TransitionRampUpMediumSharpOne0to50 = 114,
+    TransitionRampUpMediumSharpOne0to50,
     /// Transition Ramp Up Medium Sharp 2 - 0 to 50%
-    TransitionRampUpMediumSharpTwo0to50 = 115,
+    TransitionRampUpMediumSharpTwo0to50,
     /// Transition Ramp Up Short Sharp 1 - 0 to 50%
-    TransitionRampUpShortSharpOne0to50 = 116,
+    TransitionRampUpShortSharpOne0to50,
     /// Transition Ramp Up Short Sharp 2 - 0 to 50%
-    TransitionRampUpShortSharpTwo0to50 = 117,
+    TransitionRampUpShortSharpTwo0to50,
     /// Long Buzz For Programmatic Stopping - 100%
-    LongBuzzForProgrammaticStopping100 = 118,
+    LongBuzzForProgrammaticStopping100,
     /// Smooth Hum 1 (No kick or brake pulse) - 50%
-    SmoothHumOne50 = 119,
+    SmoothHumOne50,
     /// Smooth Hum 2 (No kick or brake pulse) - 40%
-    SmoothHumTwo40 = 120,
+    SmoothHumTwo40,
     /// Smooth Hum 3 (No kick or brake pulse) - 30%
-    SmoothHumThree30 = 121,
+    SmoothHumThree30,
     /// Smooth Hum 4 (No kick or brake pulse) - 20%
-    SmoothHumFour20 = 122,
+    SmoothHumFour20,
     /// Smooth Hum 5 (No kick or brake pulse) - 10%
-    SmoothHumFive10 = 123,
+    SmoothHumFive10,
 }
 
 bitfield! {
@@ -482,34 +616,6 @@ bitfield! {
     /// the sequencer reaches an identifier value of zero, or all eight identifiers are
     /// played (register addresses 0x04 through 0x0B), whichever comes first.
     waveform_seq, set_waveform_seq: 6, 0;
-}
-
-#[allow(unused)]
-impl WaveformReg {
-    /// Stops playing the sequence of effects
-    pub fn new_stop() -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(false);
-        w.set_waveform_seq(0);
-        w
-    }
-
-    /// Set the effect
-    pub fn new_effect(effect: Effect) -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(false);
-        w.set_waveform_seq(effect as u8);
-        w
-    }
-
-    /// Wait the specified amount of time (in 10ms intervals), before
-    /// moving to the next effect and playing it.
-    pub fn new_wait_time(tens_of_ms: u8) -> Self {
-        let mut w = WaveformReg(0);
-        w.set_wait(true);
-        w.set_waveform_seq(tens_of_ms);
-        w
-    }
 }
 
 bitfield! {

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,0 +1,880 @@
+use bitfield::bitfield;
+
+bitfield! {
+    pub struct StatusReg(u8);
+    impl Debug;
+    /// Latching overcurrent detection flag.  If the load impedance is below
+    /// the load-impedance threshold, the device shuts down and periodically
+    /// attempts to restart until the impedance is above the threshold
+    pub oc_detected, _: 0;
+    /// Latching overtemperature detection flag. If the device becomes too hot,
+    /// it shuts down. This bit clears upon read.
+    pub over_temp, _: 1;
+    /// Contains status for the feedback controller. This indicates when the ERM
+    /// back-EMF has been zero for more than ~10 ms in ERM mode, and
+    /// indicates when the LRA frequency tracking has lost frequency lock in LRA
+    /// mode. This bit is for debug purposes only, and may sometimes be set
+    /// under normal operation when extensive braking periods are used. This bit
+    /// will clear upon read.
+    pub feedback_controller_timed_out, _: 2;
+    /// This flag stores the result of the auto-calibration routine and the diagnostic
+    /// routine. The flag contains the result for whichever routine was executed
+    /// last. The flag clears upon read. Test result is not valid until the GO bit self-
+    /// clears at the end of the routine.
+    /// Auto-calibration mode:
+    /// 0: Auto-calibration passed (optimum result converged)
+    /// 1: Auto-calibration failed (result did not converge)
+    /// Diagnostic mode:
+    /// 0: Actuator is functioning normally
+    /// 1: Actuator is not present or is shorted, timing out, or giving
+    /// out–of-range back-EMF.
+    pub diagnostic_result, _: 3;
+    /// Device identifier. The DEVICE_ID bit indicates the part number to the user.
+    /// The user software can ascertain the device capabilities by reading this
+    /// register.
+    /// 4: DRV2604 (contains RAM, does not contain licensed ROM library)
+    /// 3: DRV2605 (contains licensed ROM library, does not contain RAM)
+    /// 6: DRV2604L (low-voltage version of the DRV2604 device)
+    /// 7: DRV2605L (low-voltage version of the DRV2605 device)
+    pub device_id, _: 7, 5;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    /// Waveforms are fired by setting the GO bit in register 0x0C.
+    InternalTrigger = 0,
+    /// A rising edge on the IN/TRIG pin sets the GO Bit. A second rising
+    /// edge on the IN/TRIG pin cancels the waveform if the second rising
+    /// edge occurs before the GO bit has cleared.
+    ExternalTriggerRisingEdge = 1,
+    /// The GO bit follows the state of the external trigger. A rising edge on
+    /// the IN/TRIG pin sets the GO bit, and a falling edge sends a cancel. If
+    /// the GO bit is already in the appropriate state, no change occurs.
+    ExternalTriggerLevel = 2,
+    /// A PWM or analog signal is accepted at the IN/TRIG pin and used as
+    /// the driving source. The device actively drives the actuator while in
+    /// this mode. The PWM or analog input selection occurs by using the
+    /// N_PWM_ANALOG bit.
+    PwmInputAndAnalogInput = 3,
+    /// An AC-coupled audio signal is accepted at the IN/TRIG pin. The
+    /// device converts the audio signal into meaningful haptic vibration. The
+    /// AC_COUPLE and N_PWM_ANALOG bits should also be set.
+    AudioToVibe = 4,
+    /// The device actively drives the actuator with the contents of the
+    /// RTP_INPUT\[7:0\] bit in register 0x02.
+    RealTimePlayback = 5,
+    /// Set the device in this mode to perform a diagnostic test on the
+    /// actuator. The user must set the GO bit to start the test. The test is
+    /// complete when the GO bit self-clears. Results are stored in the
+    /// DIAG_RESULT bit in register 0x00.
+    Diagnostics = 6,
+    /// Set the device in this mode to auto calibrate the device for the
+    /// actuator. Before starting the calibration, the user must set the all
+    /// required input parameters. The user must set the GO bit to start the
+    /// calibration. Calibration is complete when the GO bit self-clears.
+    AutoCalibration = 7,
+}
+
+impl From<u8> for Mode {
+    fn from(val: u8) -> Mode {
+        match val {
+            0 => Mode::InternalTrigger,
+            1 => Mode::ExternalTriggerRisingEdge,
+            2 => Mode::ExternalTriggerLevel,
+            3 => Mode::PwmInputAndAnalogInput,
+            4 => Mode::AudioToVibe,
+            5 => Mode::RealTimePlayback,
+            6 => Mode::Diagnostics,
+            7 => Mode::AutoCalibration,
+            _ => unreachable!("impossible value read back from Mode register"),
+        }
+    }
+}
+
+bitfield! {
+    pub struct ModeReg(u8);
+    impl Debug;
+    /// Device reset. Setting this bit performs the equivalent operation of power
+    /// cycling the device. Any playback operations are immediately interrupted,
+    /// and all registers are reset to the default values. The DEV_RESET bit self-
+    /// clears after the reset operation is complete.
+    pub dev_reset, set_dev_reset: 7;
+
+    /// Software standby mode
+    /// 0: Device ready
+    /// 1: Device in software standby
+    pub standby, set_standby: 6;
+
+    /// The `Mode`
+    pub into Mode, mode, set_mode: 2, 0;
+}
+
+#[derive(Debug)]
+pub struct RatedVoltageReg(pub u8);
+
+impl Default for RatedVoltageReg {
+    fn default() -> Self {
+        Self(0x3f)
+    }
+}
+
+#[derive(Debug)]
+pub struct OverdriveClampReg(pub u8);
+
+impl Default for OverdriveClampReg {
+    fn default() -> Self {
+        Self(0x89)
+    }
+}
+
+#[derive(Debug)]
+pub struct AutoCalibrationCompensationReg(pub u8);
+
+impl Default for AutoCalibrationCompensationReg {
+    fn default() -> Self {
+        Self(0x0D)
+    }
+}
+
+#[derive(Debug)]
+pub struct AutoCalibrationCompensationBackEmfReg(pub u8);
+
+impl Default for AutoCalibrationCompensationBackEmfReg {
+    fn default() -> Self {
+        Self(0x6D)
+    }
+}
+
+impl Default for ModeReg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_dev_reset(false);
+        reg.set_standby(true);
+        reg.set_mode(Mode::InternalTrigger as u8);
+        reg
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LibrarySelection {
+    Empty = 0,
+    A = 1,
+    B = 2,
+    C = 3,
+    D = 4,
+    E = 5,
+    Lra = 6,
+    Reserved = 7,
+}
+
+impl From<u8> for LibrarySelection {
+    fn from(val: u8) -> LibrarySelection {
+        match val {
+            0 => LibrarySelection::Empty,
+            1 => LibrarySelection::A,
+            2 => LibrarySelection::B,
+            3 => LibrarySelection::C,
+            4 => LibrarySelection::D,
+            5 => LibrarySelection::E,
+            6 => LibrarySelection::Lra,
+            7 => LibrarySelection::Reserved,
+            _ => unreachable!("impossible LibrarySelection value"),
+        }
+    }
+}
+
+bitfield! {
+    pub struct RegisterThree(u8);
+    impl Debug;
+    /// This bit sets the output driver into a true high-impedance state. The device
+    /// must be enabled to go into the high-impedance state. When in hardware
+    /// shutdown or standby mode, the output drivers have 15 kΩ to ground. When
+    /// the HI_Z bit is asserted, the hi-Z functionality takes effect immediately, even
+    /// if a transaction is taking place.
+    pub hi_z, set_hi_z: 4;
+
+    /// Waveform library selection value. This bit determines which library the
+    /// playback engine selects when the GO bit is set.
+    pub into LibrarySelection, library_selection, set_library_selection: 2, 0;
+}
+
+/// Identifies which of the waveforms from the ROM library that should
+/// be played in a given waveform slot.
+#[allow(unused)]
+#[derive(Debug, Clone, Copy)]
+pub enum Effect {
+    /// No effect
+    None = 0,
+    /// Strong Click - 100%
+    StrongClick100 = 1,
+    /// Strong Click - 60%
+    StrongClick60 = 2,
+    /// Strong Click - 30%
+    StrongClick30 = 3,
+    /// Sharp Click - 100%
+    SharpClick100 = 4,
+    /// Sharp Click - 60%
+    SharpClick60 = 5,
+    /// Sharp Click - 30%
+    SharpClick30 = 6,
+    /// Soft Bump - 100%
+    SoftBump100 = 7,
+    /// Soft Bump - 60%
+    SoftBump60 = 8,
+    /// Soft Bump - 30%
+    SoftBump30 = 9,
+    /// Double Click - 100%
+    DoubleClick100 = 10,
+    /// Double Click - 60%
+    DoubleClick60 = 11,
+    /// Triple Click - 100%
+    TripleClick100 = 12,
+    /// Soft Fuzz - 60%
+    SoftFuzz60 = 13,
+    /// Strong Buzz - 100%
+    StrongBuzz100 = 14,
+    /// 750 ms Alert 100%
+    Alert750ms = 15,
+    /// 1000 ms Alert 100%
+    Alert1000ms = 16,
+    /// Strong Click 1 - 100%
+    StrongClickOne100 = 17,
+    /// Strong Click 2 - 80%
+    StrongClickTwo80 = 18,
+    /// Strong Click 3 - 60%
+    StrongClickThree60 = 19,
+    /// Strong Click 4 - 30%
+    StrongClickFour30 = 20,
+    /// Medium Click 1 - 100%
+    MediumClickOne100 = 21,
+    /// Medium Click 2 - 80%
+    MediumClickTwo80 = 22,
+    /// Medium Click 3 - 60%
+    MediumClickThree60 = 23,
+    /// Sharp Tick 1 - 100%
+    SharpTickOne100 = 24,
+    /// Sharp Tick 2 - 80%
+    SharpTickTwo80 = 25,
+    /// Sharp Tick 3 - 60%
+    SharpTickThree60 = 26,
+    /// Short Double Click Strong 1 - 100%
+    ShortDoubleClickStrongOne100 = 27,
+    /// Short Double Click Strong 2 - 80%
+    ShortDoubleClickStrongTwo80 = 28,
+    /// Short Double Click Strong 3 - 60%
+    ShortDoubleClickStrongThree60 = 29,
+    /// Short Double Click Strong 4 - 30%
+    ShortDoubleClickStrongFour30 = 30,
+    /// Short Double Click Medium 1 - 100%
+    ShortDoubleClickMediumOne100 = 31,
+    /// Short Double Click Medium 2 - 80%
+    ShortDoubleClickMediumTwo80 = 32,
+    /// Short Double Click Medium 3 - 60%
+    ShortDoubleClickMediumThree60 = 33,
+    /// Short Double Sharp Tick 1 - 100%
+    ShortDoubleSharpTickOne100 = 34,
+    /// Short Double Sharp Tick 2 - 80%
+    ShortDoubleSharpTickTwo80 = 35,
+    /// Short Double Sharp Tick 3 - 60%
+    ShortDoubleSharpTickThree60 = 36,
+    /// Long Double Sharp Click Strong 1 - 100%
+    LongDoubleSharpClickStrongOne100 = 37,
+    /// Long Double Sharp Click Strong 2 - 80%
+    LongDoubleSharpClickStrongTwo80 = 38,
+    /// Long Double Sharp Click Strong 3 - 60%
+    LongDoubleSharpClickStrongThree60 = 39,
+    /// Long Double Sharp Click Strong 4 - 30%
+    LongDoubleSharpClickStrongFour30 = 40,
+    /// Long Double Sharp Click Medium 1 - 100%
+    LongDoubleSharpClickMediumOne100 = 41,
+    /// Long Double Sharp Click Medium 2 - 80%
+    LongDoubleSharpClickMediumTwo80 = 42,
+    /// Long Double Sharp Click Medium 3 - 60%
+    LongDoubleSharpClickMediumThree60 = 43,
+    /// Long Double Sharp Tick 1 - 100%
+    LongDoubleSharpTickOne100 = 44,
+    /// Long Double Sharp Tick 2 - 80%
+    LongDoubleSharpTickTwo80 = 45,
+    /// Long Double Sharp Tick 3 - 60%
+    LongDoubleSharpTickThree60 = 46,
+    /// Buzz 1 - 100%
+    BuzzOne100 = 47,
+    /// Buzz 2 - 80%
+    BuzzTwo80 = 48,
+    /// Buzz 3 - 60%
+    BuzzThree60 = 49,
+    /// Buzz 4 - 40%
+    BuzzFour40 = 50,
+    /// Buzz 5 - 20%
+    BuzzFive20 = 51,
+    /// Pulsing Strong 1 - 100%
+    PulsingStrongOne100 = 52,
+    /// Pulsing Strong 2 - 60%
+    PulsingStrongTwo60 = 53,
+    /// Pulsing Medium 1 - 100%
+    PulsingMediumOne100 = 54,
+    /// Pulsing Medium 2 - 60%
+    PulsingMediumTwo60 = 55,
+    /// Pulsing Sharp 1 - 100%
+    PulsingSharpOne100 = 56,
+    /// Pulsing Sharp 2 - 60%
+    PulsingSharpTwo60 = 57,
+    /// Transition Click 1 - 100%
+    TransitionClickOne100 = 58,
+    /// Transition Click 2 - 80%
+    TransitionClickTwo80 = 59,
+    /// Transition Click 3 - 60%
+    TransitionClickThree60 = 60,
+    /// Transition Click 4 - 40%
+    TransitionClickFour40 = 61,
+    /// Transition Click 5 - 20%
+    TransitionClickFive20 = 62,
+    /// Transition Click 6 - 10%
+    TransitionClickSix10 = 63,
+    /// Transition Hum 1 - 100%
+    TransitionHumOne100 = 64,
+    /// Transition Hum 2 - 80%
+    TransitionHumTwo80 = 65,
+    /// Transition Hum 3 - 60%
+    TransitionHumThree60 = 66,
+    /// Transition Hum 4 - 40%
+    TransitionHumFour40 = 67,
+    /// Transition Hum 5 - 20%
+    TransitionHumFive20 = 68,
+    /// Transition Hum 6 - 10%
+    TransitionHumSix10 = 69,
+    /// Transition Ramp Down Long Smooth 1 - 100 to 0%
+    TransitionRampDownLongSmoothOne100to0 = 70,
+    /// Transition Ramp Down Long Smooth 2 - 100 to 0%
+    TransitionRampDownLongSmoothTwo100to0 = 71,
+    /// Transition Ramp Down Medium Smooth 1 - 100 to 0%
+    TransitionRampDownMediumSmoothOne100to0 = 72,
+    /// Transition Ramp Down Medium Smooth 2 - 100 to 0%
+    TransitionRampDownMediumSmoothTwo100to0 = 73,
+    /// Transition Ramp Down Short Smooth 1 - 100 to 0%
+    TransitionRampDownShortSmoothOne100to0 = 74,
+    /// Transition Ramp Down Short Smooth 2 - 100 to 0%
+    TransitionRampDownShortSmoothTwo100to0 = 75,
+    /// Transition Ramp Down Long Sharp 1 - 100 to 0%
+    TransitionRampDownLongSharpOne100to0 = 76,
+    /// Transition Ramp Down Long Sharp 2 - 100 to 0%
+    TransitionRampDownLongSharpTwo100to0 = 77,
+    /// Transition Ramp Down Medium Sharp 1 - 100 to 0%
+    TransitionRampDownMediumSharpOne100to0 = 78,
+    /// Transition Ramp Down Medium Sharp 2 - 100 to 0%
+    TransitionRampDownMediumSharpTwo100to0 = 79,
+    /// Transition Ramp Down Short Sharp 1 - 100 to 0%
+    TransitionRampDownShortSharpOne100to0 = 80,
+    /// Transition Ramp Down Short Sharp 2 - 100 to 0%
+    TransitionRampDownShortSharpTwo100to0 = 81,
+    /// Transition Ramp Up Long Smooth 1 - 0 to 100%
+    TransitionRampUpLongSmoothOne0to100 = 82,
+    /// Transition Ramp Up Long Smooth 2 - 0 to 100%
+    TransitionRampUpLongSmoothTwo0to100 = 83,
+    /// Transition Ramp Up Medium Smooth 1 - 0 to 100%
+    TransitionRampUpMediumSmoothOne0to100 = 84,
+    /// Transition Ramp Up Medium Smooth 2 - 0 to 100%
+    TransitionRampUpMediumSmoothTwo0to100 = 85,
+    /// Transition Ramp Up Short Smooth 1 - 0 to 100%
+    TransitionRampUpShortSmoothOne0to100 = 86,
+    /// Transition Ramp Up Short Smooth 2 - 0 to 100%
+    TransitionRampUpShortSmoothTwo0to100 = 87,
+    /// Transition Ramp Up Long Sharp 1 - 0 to 100%
+    TransitionRampUpLongSharpOne0to100 = 88,
+    /// Transition Ramp Up Long Sharp 2 - 0 to 100%
+    TransitionRampUpLongSharpTwo0to100 = 89,
+    /// Transition Ramp Up Medium Sharp 1 - 0 to 100%
+    TransitionRampUpMediumSharpOne0to100 = 90,
+    /// Transition Ramp Up Medium Sharp 2 - 0 to 100%
+    TransitionRampUpMediumSharpTwo0to100 = 91,
+    /// Transition Ramp Up Short Sharp 1 - 0 to 100%
+    TransitionRampUpShortSharpOne0to100 = 92,
+    /// Transition Ramp Up Short Sharp 2 - 0 to 100%
+    TransitionRampUpShortSharpTwo0to100 = 93,
+    /// Transition Ramp Down Long Smooth 1 - 50 to 0%
+    TransitionRampDownLongSmoothOne50to0 = 94,
+    /// Transition Ramp Down Long Smooth 2 - 50 to 0%
+    TransitionRampDownLongSmoothTwo50to0 = 95,
+    /// Transition Ramp Down Medium Smooth 1 - 50 to 0%
+    TransitionRampDownMediumSmoothOne50to0 = 96,
+    /// Transition Ramp Down Medium Smooth 2 - 50 to 0%
+    TransitionRampDownMediumSmoothTwo50to0 = 97,
+    /// Transition Ramp Down Short Smooth 1 - 50 to 0%
+    TransitionRampDownShortSmoothOne50to0 = 98,
+    /// Transition Ramp Down Short Smooth 2 - 50 to 0%
+    TransitionRampDownShortSmoothTwo50to0 = 99,
+    /// Transition Ramp Down Long Sharp 1 - 50 to 0%
+    TransitionRampDownLongSharpOne50to0 = 100,
+    /// Transition Ramp Down Long Sharp 2 - 50 to 0%
+    TransitionRampDownLongSharpTwo50to0 = 101,
+    /// Transition Ramp Down Medium Sharp 1 - 50 to 0%
+    TransitionRampDownMediumSharpOne50to0 = 102,
+    /// Transition Ramp Down Medium Sharp 2 - 50 to 0%
+    TransitionRampDownMediumSharpTwo50to0 = 103,
+    /// Transition Ramp Down Short Sharp 1 - 50 to 0%
+    TransitionRampDownShortSharpOne50to0 = 104,
+    /// Transition Ramp Down Short Sharp 2 - 50 to 0%
+    TransitionRampDownShortSharpTwo50to0 = 105,
+    /// Transition Ramp Up Long Smooth 1 - 0 to 50%
+    TransitionRampUpLongSmoothOne0to50 = 106,
+    /// Transition Ramp Up Long Smooth 2 - 0 to 50%
+    TransitionRampUpLongSmoothTwo0to50 = 107,
+    /// Transition Ramp Up Medium Smooth 1 - 0 to 50%
+    TransitionRampUpMediumSmoothOne0to50 = 108,
+    /// Transition Ramp Up Medium Smooth 2 - 0 to 50%
+    TransitionRampUpMediumSmoothTwo0to50 = 109,
+    /// Transition Ramp Up Short Smooth 1 - 0 to 50%
+    TransitionRampUpShortSmoothOne0to50 = 110,
+    /// Transition Ramp Up Short Smooth 2 - 0 to 50%
+    TransitionRampUpShortSmoothTwo0to50 = 111,
+    /// Transition Ramp Up Long Sharp 1 - 0 to 50%
+    TransitionRampUpLongSharpOne0to50 = 112,
+    /// Transition Ramp Up Long Sharp 2 - 0 to 50%
+    TransitionRampUpLongSharpTwo0to50 = 113,
+    /// Transition Ramp Up Medium Sharp 1 - 0 to 50%
+    TransitionRampUpMediumSharpOne0to50 = 114,
+    /// Transition Ramp Up Medium Sharp 2 - 0 to 50%
+    TransitionRampUpMediumSharpTwo0to50 = 115,
+    /// Transition Ramp Up Short Sharp 1 - 0 to 50%
+    TransitionRampUpShortSharpOne0to50 = 116,
+    /// Transition Ramp Up Short Sharp 2 - 0 to 50%
+    TransitionRampUpShortSharpTwo0to50 = 117,
+    /// Long Buzz For Programmatic Stopping - 100%
+    LongBuzzForProgrammaticStopping100 = 118,
+    /// Smooth Hum 1 (No kick or brake pulse) - 50%
+    SmoothHumOne50 = 119,
+    /// Smooth Hum 2 (No kick or brake pulse) - 40%
+    SmoothHumTwo40 = 120,
+    /// Smooth Hum 3 (No kick or brake pulse) - 30%
+    SmoothHumThree30 = 121,
+    /// Smooth Hum 4 (No kick or brake pulse) - 20%
+    SmoothHumFour20 = 122,
+    /// Smooth Hum 5 (No kick or brake pulse) - 10%
+    SmoothHumFive10 = 123,
+}
+
+bitfield! {
+    pub struct WaveformReg(u8);
+    impl Debug;
+    /// When this bit is set, the WAV_FRM_SEQ[6:0] bit is interpreted as a wait
+    /// time in which the playback engine idles. This bit is used to insert timed
+    /// delays between sequentially played waveforms.
+    /// Delay time = 10 ms × WAV_FRM_SEQ[6:0]
+    /// If WAIT = 0, then WAV_FRM_SEQ[6:0] is interpreted as a waveform
+    /// identifier for sequence playback.
+    wait, set_wait: 7;
+
+    /// Waveform sequence value. This bit holds the waveform identifier of the
+    /// waveform to be played. A waveform identifier is an integer value referring
+    /// to the index position of a waveform in a ROM library. Playback begins at
+    /// register address 0x04 when the user asserts the GO bit (register 0x0C).
+    /// When playback of that waveform ends, the waveform sequencer plays the
+    /// next waveform identifier held in register 0x05, if the next waveform
+    /// identifier is non-zero. The waveform sequencer continues in this way until
+    /// the sequencer reaches an identifier value of zero, or all eight identifiers are
+    /// played (register addresses 0x04 through 0x0B), whichever comes first.
+    waveform_seq, set_waveform_seq: 6, 0;
+}
+
+#[allow(unused)]
+impl WaveformReg {
+    /// Stops playing the sequence of effects
+    pub fn new_stop() -> Self {
+        let mut w = WaveformReg(0);
+        w.set_wait(false);
+        w.set_waveform_seq(0);
+        w
+    }
+
+    /// Set the effect
+    pub fn new_effect(effect: Effect) -> Self {
+        let mut w = WaveformReg(0);
+        w.set_wait(false);
+        w.set_waveform_seq(effect as u8);
+        w
+    }
+
+    /// Wait the specified amount of time (in 10ms intervals), before
+    /// moving to the next effect and playing it.
+    pub fn new_wait_time(tens_of_ms: u8) -> Self {
+        let mut w = WaveformReg(0);
+        w.set_wait(true);
+        w.set_waveform_seq(tens_of_ms);
+        w
+    }
+}
+
+bitfield! {
+    pub struct GoReg(u8);
+    impl Debug;
+    /// This bit is used to fire processes in the DRV2605 device. The process
+    /// fired by the GO bit is selected by the MODE[2:0] bit (register 0x01). The
+    /// primary function of this bit is to fire playback of the waveform identifiers in
+    /// the waveform sequencer (registers 0x04 to 0x0B), in which case, this bit
+    /// can be thought of a software trigger for haptic waveforms. The GO bit
+    /// remains high until the playback of the haptic waveform sequence is
+    /// complete. Clearing the GO bit during waveform playback cancels the
+    /// waveform sequence. Using one of the external trigger modes can cause
+    /// the GO bit to be set or cleared by the external trigger pin. This bit can also
+    /// be used to fire the auto-calibration process or the diagnostic process.
+    pub go, set_go: 0;
+}
+
+bitfield! {
+    pub struct FeedbackControlReg(u8);
+    impl Debug;
+
+    /// This bit sets the DRV2605 device in ERM or LRA mode. This bit should be set
+    /// prior to running auto calibration.
+    /// 0: ERM Mode
+    /// 1: LRA Mode
+    pub n_erm_lra, set_n_erm_lra: 7;
+
+    /// This bit selects the feedback gain ratio between braking gain and driving gain.
+    /// In general, adding additional feedback gain while braking is desirable so that the
+    /// actuator brakes as quickly as possible. Large ratios provide less-stable
+    /// operation than lower ones. The advanced user can select to optimize this
+    /// register. Otherwise, the default value should provide good performance for most
+    /// actuators. This value should be set prior to running auto calibration.
+    /// 0: 1x
+    /// 1: 2x
+    /// 2: 3x
+    /// 3: 4x
+    /// 4: 6x
+    /// 5: 8x
+    /// 6: 16x
+    /// 7: Braking disabled
+    pub fb_brake_factor, set_fb_brake_factor: 6, 4;
+
+    /// This bit selects a loop gain for the feedback control. The LOOP_GAIN[1:0] bit
+    /// sets how fast the loop attempts to make the back-EMF (and thus motor velocity)
+    /// match the input signal level. Higher loop-gain (faster settling) options provide
+    /// less-stable operation than lower loop gain (slower settling). The advanced user
+    /// can select to optimize this register. Otherwise, the default value should provide
+    /// good performance for most actuators. This value should be set prior to running
+    /// auto calibration.
+    /// 0: Low
+    /// 1: Medium (default)
+    /// 2: High
+    /// 3: Very High
+    pub loop_gain, set_loop_gain: 3, 2;
+
+    /// This bit sets the analog gain of the back-EMF amplifier. This value is interpreted
+    /// differently between ERM mode and LRA mode. Auto calibration automatically
+    /// populates the BEMF_GAIN bit with the most appropriate value for the actuator.
+    /// ERM Mode
+    /// 0: 0.33x
+    /// 1: 1.0x
+    /// 2: 1.8x (default)
+    /// 3: 4.0x
+    /// LRA Mode
+    /// 0: 5x
+    /// 1: 10x
+    /// 2: 20x (default)
+    /// 3: 30x
+    pub bemf_gain, set_bemf_gain: 1, 0;
+}
+
+impl Default for FeedbackControlReg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_n_erm_lra(false);
+        reg.set_fb_brake_factor(0x3);
+        reg.set_loop_gain(0x1);
+        reg.set_bemf_gain(0x2);
+        reg
+    }
+}
+
+bitfield! {
+    pub struct Control1Reg(u8);
+    impl Debug;
+    /// This bit applies higher loop gain during overdrive to enhance actuator transient response.
+    pub startup_boost, set_startup_boost: 7;
+    /// This bit applies a 0.9-V common mode voltage to the IN/TRIG pin when an AC-
+    /// coupling capacitor is used. This bit is only useful for analog input mode. This bit
+    /// should not be asserted for PWM mode or external trigger mode.
+    /// 0: Common-mode drive disabled for DC-coupling or digital inputs modes
+    /// 1: Common-mode drive enabled for AC coupling
+    pub ac_couple, set_ac_couple: 5;
+    /// LRA Mode: Sets initial guess for LRA drive-time in LRA mode. Drive time is
+    /// automatically adjusted for optimum drive in real time; however, this register
+    /// should be optimized for the approximate LRA frequency. If the bit is set too low,
+    /// it can affect the actuator startup time. If it is set too high, it can cause instability.
+    /// Optimum drive time (ms) ≈ 0.5 × LRA Period
+    /// Drive time (ms) = DRIVE_TIME[4:0] × 0.1 ms + 0.5 ms
+    /// ERM Mode: Sets the sample rate for the back-EMF detection. Lower drive times
+    /// cause higher peak-to-average ratios in the output signal, requiring more supply
+    /// headroom. Higher drive times cause the feedback to react at a slower rate.
+    /// Drive Time (ms) = DRIVE_TIME[4:0] × 0.2 ms + 1 ms
+    pub drive_time, set_drive_time: 4, 0;
+}
+
+impl Default for Control1Reg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_startup_boost(true);
+        reg.set_ac_couple(false);
+        reg.set_drive_time(0x13);
+        reg
+    }
+}
+
+bitfield! {
+    pub struct Control2Reg(u8);
+    impl Debug;
+    /// The BIDIR_INPUT bit selects how the engine interprets data.
+    /// 0: Unidirectional input mode
+    /// Braking is automatically determined by the feedback conditions and is
+    /// applied when needed. Use of this mode also recovers an additional bit
+    /// of vertical resolution. This mode should only be used for closed-loop
+    /// operation.
+    /// Examples::
+    /// 0% Input -> No output signal
+    /// 50% Input -> Half-scale output signal
+    /// 100% Input -> Full-scale output signal
+    /// 1: Bidirectional input mode (default)
+    /// This mode is compatible with traditional open-loop signaling and also
+    /// works well with closed-loop mode. When operating closed-loop, braking
+    /// is automatically determined by the feedback conditions and applied
+    /// when needed. When operating open-loop modes, braking is only
+    /// applied when the input signal is less than 50%.
+    /// Open-loop mode (ERM and LRA) examples:
+    /// 0% Input -> Negative full-scale output signal (braking)
+    /// 25% Input -> Negative half-scale output signal (braking)
+    /// 50% Input -> No output signal
+    /// 75% Input -> Positive half-scale output signal
+    /// 100% Input -> Positive full-scale output signal
+    /// Closed-loop mode (ERM and LRA) examples:
+    /// 0% to 50% Input -> No output signal
+    /// 50% Input -> No output signal
+    /// 75% Input -> Half-scale output signal
+    /// 100% Input -> Full-scale output signal
+    pub bidir_input, set_bidir_input: 7;
+    /// When this bit is set, loop gain is reduced when braking is almost complete to
+    /// improve loop stability
+    pub brake_stabilizer, set_brake_stabilizer: 6;
+    /// LRA auto-resonance sampling time (Advanced use only)
+    /// 0: 150 us
+    /// 1: 200 us
+    /// 2: 250 us
+    /// 3: 300 us
+    pub sample_time, set_sample_time: 5, 4;
+    /// Blanking time before the back-EMF AD makes a conversion. (Advanced use only)
+    pub blanking_time, set_blanking_time: 3, 2;
+    /// Current dissipation time. This bit is the time allowed for the current to dissipate
+    /// from the actuator between PWM cycles for flyback mitigation. (Advanced use
+    /// only)
+    pub idiss_time, set_idiss_time: 1, 0;
+}
+
+impl Default for Control2Reg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_bidir_input(true);
+        reg.set_brake_stabilizer(true);
+        reg.set_sample_time(0x3);
+        reg.set_blanking_time(0x1);
+        reg.set_idiss_time(0x1);
+        reg
+    }
+}
+
+bitfield! {
+    pub struct Control3Reg(u8);
+    impl Debug;
+
+    /// This bit is the noise-gate threshold for PWM and analog inputs.
+    /// 0: Disabled
+    /// 1: 2%
+    /// 2: 4% (Default)
+    /// 3: 8%
+    pub ng_thresh, set_ng_thresh: 7, 6;
+    /// This bit selects mode of operation while in ERM mode. Closed-loop operation is
+    /// usually desired for because of automatic overdrive and braking properties.
+    /// However, many existing waveform libraries were designed for open-loop
+    /// operation, so open-loop operation may be required for compatibility.
+    /// 0: Closed Loop
+    /// 1: Open Loop
+    pub erm_open_loop, set_erm_open_loop: 5;
+    /// This bit disables supply compensation. The DRV2605 device generally provides
+    /// constant drive output over variation in the power supply input (V DD ). In some
+    /// systems, supply compensation may have already been implemented upstream,
+    /// so disabling the DRV2605 supply compensation can be useful.
+    /// 0: Supply compensation enabled
+    /// 1: Supply compensation disabled
+    pub supply_comp_dis, set_supply_comp_dis: 4;
+    /// This bit selects the input data interpretation for RTP (Real-Time Playback)
+    /// mode.
+    /// 0: Signed
+    /// 1: Unsigned
+    pub data_format_rtp, set_data_format_rtp: 3;
+    /// This bit selects the drive mode for the LRA algorithm. This bit determines how
+    /// often the drive amplitude is updated. Updating once per cycle provides a
+    /// symmetrical output signal, while updating twice per cycle provides more precise
+    /// control.
+    /// 0: Once per cycle
+    /// 1: Twice per cycle
+    pub lra_drive_mode, set_lra_drive_mode: 2;
+    /// This bit selects the input mode for the IN/TRIG pin when MODE[2:0] = 3. In
+    /// PWM input mode, the duty cycle of the input signal determines the amplitude of
+    /// the waveform. In analog input mode, the amplitude of the input determines the
+    /// amplitude of the waveform.
+    /// 0: PWM Input
+    /// 1: Analog Input
+    pub n_pwm_analog, set_n_pwm_analog: 1;
+    /// This bit selects an open-loop drive option for LRA Mode. When asserted, the
+    /// playback engine drives the LRA at the selected frequency independently of the
+    /// resonance frequency. In PWM input mode, the playback engine recovers the
+    /// LRA commutation frequency from the PWM input, dividing the frequency by
+    /// 128. Therefore the PWM input frequency must be equal to 128 times the
+    /// resonant frequency of the LRA.
+    /// 0: Auto-resonance mode
+    /// 1: LRA open-loop mode
+    pub lra_open_loop, set_lra_open_loop: 0;
+}
+
+impl Default for Control3Reg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_ng_thresh(0x2);
+        reg.set_erm_open_loop(true);
+        reg.set_supply_comp_dis(false);
+        reg.set_data_format_rtp(false);
+        reg.set_lra_drive_mode(false);
+        reg.set_n_pwm_analog(false);
+        reg.set_lra_open_loop(false);
+        reg
+    }
+}
+
+bitfield! {
+    pub struct Control4Reg(u8);
+    impl Debug;
+
+    /// This bit sets the minimum length of time devoted for detecting a zero crossing.
+    /// (advanced use only). Only documented on l models?
+    /// 0: 100 us (Default)
+    /// 1: 200 us
+    /// 2: 300 us
+    /// 3: 390 us
+    pub zc_det_time, set_zc_det_time: 7, 6;
+
+    /// This bit sets the length of the auto calibration time. The AUTO_CAL_TIME[1:0]
+    /// bit should be enough time for the motor acceleration to settle when driven at the
+    /// RATED_VOLTAGE[7:0] value.
+    /// 0: 150 ms (minimum), 350 ms (maximum)
+    /// 1: 250 ms (minimum), 450 ms (maximum)
+    /// 2: 500 ms (minimum), 700 ms (maximum)
+    /// 3: 1000 ms (minimum), 1200 ms (maximum)
+    pub auto_cal_time, set_auto_cal_time: 5, 4;
+
+    /// OTP Memory status
+    /// 0: OTP Memory has not been programmed
+    /// 1: OTP Memory has been programmed
+    pub otp_status, set_otp_status: 2;
+
+    /// This bit launches the programming process for one-time programmable
+    /// (OTP) memory which programs the contents of register 0x16 through 0x1A
+    /// into nonvolatile memory. This process can only be executed one time per
+    /// device. See the Programming On-Chip OTP Memory section for details.
+    pub otp_program, set_otp_program: 1;
+}
+
+impl Default for Control4Reg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_auto_cal_time(0x2);
+        reg.set_otp_program(false);
+        reg
+    }
+}
+
+#[allow(unused)]
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Register {
+    Status = 0,
+    Mode = 1,
+    /// This field is the entry point for real-time playback (RTP) data. The
+    /// DRV2605 playback engine drives the RTP_INPUT[7:0] value to the load when
+    /// MODE[2:0] = 5 (RTP mode). The RTP_INPUT[7:0] value can be updated in
+    /// real-time by the host controller to create haptic waveforms. The
+    /// RTP_INPUT[7:0] value is interpreted as signed by default, but can be set
+    /// to unsigned by the DATA_FORMAT_RTP bit in register 0x1D. When the haptic
+    /// waveform is complete, the user can idle the device by setting MODE[2:0]
+    /// = 0, or alternatively by setting STANDBY = 1.
+    RealTimePlaybackInput = 2,
+    Register3 = 3,
+    WaveformSequence0 = 4,
+    WaveformSequence1 = 5,
+    WaveformSequence2 = 6,
+    WaveformSequence3 = 7,
+    WaveformSequence4 = 8,
+    WaveformSequence5 = 9,
+    WaveformSequence6 = 0xa,
+    WaveformSequence7 = 0xb,
+    Go = 0xc,
+    OverdriveTimeOffset = 0xd,
+    SustainTimeOffsetPositive = 0xe,
+    SustainTimeOffsetNegative = 0xf,
+    BrakeTimeOffset = 0x10,
+
+    /// This bit sets the reference voltage for full-scale output during
+    /// closed-loop operation. The auto-calibration routine uses this register
+    /// as an input, so this register must be written with the rated voltage
+    /// value of the motor before calibration is performed. This register is
+    /// ignored for open-loop operation because the overdrive voltage sets the
+    /// reference for that case. Any modification of this register value should
+    /// be followed by calibration to set A_CAL_BEMF appropriately.
+    ///
+    /// See the Rated Voltage Programming section for calculating the correct
+    /// register value.
+    RatedVoltage = 0x16,
+
+    /// During closed-loop operation the actuator feedback allows the output
+    /// voltage to go above the rated voltage during the automatic overdrive and
+    /// automatic braking periods. This register sets a clamp so that the
+    /// automatic overdrive is bounded. This bit also serves as the full-scale
+    /// reference voltage for open-loop operation.
+    ///
+    /// See the Overdrive Voltage-Clamp Programming section for calculating the
+    /// correct register value.
+    ///
+    /// 8.5.2.2 Overdrive Voltage-Clamp Programming LRA and ERM are swapped,
+    /// confirmed https://e2e.ti.com/support/other_analog/haptics/f/927/t/655886
+    /// (21.64x10-3 x OD_CLAMP[7:0] x (tDRIVE_TIME - 300x10^-6)) / (tDRIVE_TIME
+    /// + tIDISS_TIME + tBLANKING_TIME)
+    OverdriveClampVoltage = 0x17,
+
+    /// This register contains the voltage-compensation result after execution
+    /// of auto calibration. The value stored in the A_CAL_COMP bit compensates
+    /// for any resistive losses in the driver. The calibration routine checks
+    /// the impedance of the actuator to automatically determine an appropriate
+    /// value. The auto- calibration compensation-result value is multiplied by
+    /// the drive gain during playback.
+    ///
+    /// Auto-calibration compensation coefficient = 1 + A_CAL_COMP[7:0] / 255
+    AutoCalibrationCompensationResult = 0x18,
+
+    /// This register contains the rated back-EMF result after execution of auto
+    /// calibration. The A_CAL_BEMF[7:0] bit is the level of back-EMF voltage that the
+    /// actuator gives when the actuator is driven at the rated voltage. The DRV2605
+    /// playback engine uses this the value stored in this bit to automatically determine
+    /// the appropriate feedback gain for closed-loop operation.
+    /// Auto-calibration back-EMF (V) = (A_CAL_BEMF[7:0] / 255) × 1.22 V /
+    /// BEMF_GAIN[1:0]
+    AutoCalibrationBackEMFResult = 0x19,
+
+    LRAOpenLoopPeriod = 0x20,
+
+    FeedbackControl = 0x1a,
+
+    Control1 = 0x1b,
+    Control2 = 0x1c,
+    Control3 = 0x1d,
+    Control4 = 0x1e,
+
+    // todo
+    Control5 = 0x1f,
+}

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -191,6 +191,9 @@ impl Default for ModeReg {
     }
 }
 
+/// Selection of Library of built-in waveforms. Each library offers all the same
+/// waveforms, but is tuned to work for different motors so it is important to
+/// choose the correct library for your motor characteristics
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Library {
     /// No library selected
@@ -374,8 +377,8 @@ impl From<Effect> for u8 {
     }
 }
 
-/// Identifies which of the waveforms from the ROM library that should
-/// be played in a given waveform slot.
+/// Selection of built-in waveforms that can be sequenced using the `set_rom`
+/// and `set_rom_single` function and triggered using the `set_go` function
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Effect {

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -209,7 +209,7 @@ bitfield! {
 impl From<Effect> for u8 {
     fn from(val: Effect) -> Self {
         match val {
-            Effect::Delays(n) => n & 0x80,
+            Effect::Delays(n) => n | 0x80,
             Effect::Stop => 0,
             Effect::StrongClick100 => 1,
             Effect::StrongClick60 => 2,
@@ -341,7 +341,7 @@ impl From<Effect> for u8 {
 /// Identifies which of the waveforms from the ROM library that should
 /// be played in a given waveform slot.
 #[allow(unused)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Effect {
     /// No effect, or Stop playing
     Stop,

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -145,6 +145,42 @@ impl Default for AutoCalibrationCompensationBackEmfReg {
     }
 }
 
+#[derive(Debug)]
+pub struct OverdriveTimeOffsetReg(pub u8);
+
+impl Default for OverdriveTimeOffsetReg {
+    fn default() -> Self {
+        Self(0x0)
+    }
+}
+
+#[derive(Debug)]
+pub struct SustainTimeOffsetPositiveReg(pub u8);
+
+impl Default for SustainTimeOffsetPositiveReg {
+    fn default() -> Self {
+        Self(0x0)
+    }
+}
+
+#[derive(Debug)]
+pub struct SustainTimeOffsetNegativeReg(pub u8);
+
+impl Default for SustainTimeOffsetNegativeReg {
+    fn default() -> Self {
+        Self(0x0)
+    }
+}
+
+#[derive(Debug)]
+pub struct BrakeTimeOffsetReg(pub u8);
+
+impl Default for BrakeTimeOffsetReg {
+    fn default() -> Self {
+        Self(0x0)
+    }
+}
+
 impl Default for ModeReg {
     fn default() -> Self {
         let mut reg = Self(0);
@@ -900,6 +936,50 @@ impl Default for Control4Reg {
         let mut reg = Self(0);
         reg.set_auto_cal_time(0x2);
         reg.set_otp_program(false);
+        reg
+    }
+}
+
+bitfield! {
+    pub struct Control5Reg(u8);
+    impl Debug;
+
+    /// This bit selects number of cycles required to attempt synchronization
+    /// before transitioning to open loop when the LRA_AUTO_OPEN_LOOP bit is
+    /// asserted,
+    /// 0: 3 attempts (Default)
+    /// 1: 4 attempts
+    /// 2: 5 attempts
+    /// 3: 6 attempts
+    pub auto_ol_cnt, set_auto_ol_cnt: 7, 6;
+
+    /// This bit selects the automatic transition to open-loop drive when a
+    /// back-EMF signal is not detected (LRA only).
+    ///
+    /// 0: Never transitions to open loop (Default)
+    /// 1: Automatically transitions to open loop
+    pub lra_auto_open_loop, set_lra_auto_open_loop: 5;
+
+    /// This bit selects the memory playback interval
+    /// 0: 5ms (Default)
+    /// 1: 1ms
+    pub playback_interval, set_playback_interval: 4;
+
+    /// Thhis bit sets the MSB for the BLANKING_TIME[3:0]. See the
+    /// BLANKING_TIME[3:0] bit in the Control2 (Address: 0x1C) section for details.
+    /// Advanced use only.
+    pub blanking_time_msb, set_blanking_time_mss: 3,2;
+
+    /// This bit sets the MSB for IDISS_TIME[3:0]. See the IDISS_TIME[1:0] bit
+    /// in the Control2 section for details. Advanced use only
+    pub idiss_time_msb, set_idiss_time_msb: 1;
+
+}
+
+impl Default for Control5Reg {
+    fn default() -> Self {
+        let mut reg = Self(0);
+        reg.set_auto_ol_cnt(0x2);
         reg
     }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -155,30 +155,38 @@ impl Default for ModeReg {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum LibrarySelection {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Library {
+    // No library selected
     Empty = 0,
+    /// Rated Voltage 1.3V Overdrive Voltage 3V Rise Time 40-60ms Brake Time 20-40ms
     A = 1,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 40-60ms Brake Time 5-15ms
     B = 2,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 60-80ms Brake Time 10-20ms
     C = 3,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time 100-140ms Brake Time 15-25ms
     D = 4,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time >140ms Brake Time >30ms
     E = 5,
+    /// Rated Voltage 3V Overdrive Voltage 3V Rise Time >140ms Brake Time >30ms
     Lra = 6,
+    /// Rated Voltage 4.5V Overdrive Voltage 5V Rise Time 35-45ms Brake Time 10-20ms
     Reserved = 7,
 }
 
-impl From<u8> for LibrarySelection {
-    fn from(val: u8) -> LibrarySelection {
+impl From<u8> for Library {
+    fn from(val: u8) -> Library {
         match val {
-            0 => LibrarySelection::Empty,
-            1 => LibrarySelection::A,
-            2 => LibrarySelection::B,
-            3 => LibrarySelection::C,
-            4 => LibrarySelection::D,
-            5 => LibrarySelection::E,
-            6 => LibrarySelection::Lra,
-            7 => LibrarySelection::Reserved,
-            _ => unreachable!("impossible LibrarySelection value"),
+            0 => Library::Empty,
+            1 => Library::A,
+            2 => Library::B,
+            3 => Library::C,
+            4 => Library::D,
+            5 => Library::E,
+            6 => Library::Lra,
+            7 => Library::Reserved,
+            _ => unreachable!("impossible Library value"),
         }
     }
 }
@@ -195,7 +203,7 @@ bitfield! {
 
     /// Waveform library selection value. This bit determines which library the
     /// playback engine selects when the GO bit is set.
-    pub into LibrarySelection, library_selection, set_library_selection: 2, 0;
+    pub into Library, library_selection, set_library_selection: 2, 0;
 }
 
 /// Identifies which of the waveforms from the ROM library that should

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -172,7 +172,7 @@ pub enum Library {
     /// Rated Voltage 3V Overdrive Voltage 3V Rise Time >140ms Brake Time >30ms
     Lra = 6,
     /// Rated Voltage 4.5V Overdrive Voltage 5V Rise Time 35-45ms Brake Time 10-20ms
-    Reserved = 7,
+    F = 7,
 }
 
 impl From<u8> for Library {
@@ -185,7 +185,7 @@ impl From<u8> for Library {
             4 => Library::D,
             5 => Library::E,
             6 => Library::Lra,
-            7 => Library::Reserved,
+            7 => Library::F,
             _ => unreachable!("impossible Library value"),
         }
     }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -193,7 +193,7 @@ impl Default for ModeReg {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Library {
-    // No library selected
+    /// No library selected
     Empty = 0,
     /// Rated Voltage 1.3V Overdrive Voltage 3V Rise Time 40-60ms Brake Time 20-40ms
     A = 1,
@@ -1074,7 +1074,6 @@ pub enum Register {
     Control3 = 0x1d,
     Control4 = 0x1e,
 
-    // todo
     Control5 = 0x1f,
 
     LRAOpenLoopPeriod = 0x20,


### PR DESCRIPTION
Hey, thanks for the library.

Drv260x is kind of my hello world driver and I found your work. Are you interested in genericising this library to support drv2604 and also lra motors or would you prefer I just fork?

This is the just the start of what I was thinking. The goal is to use type state to enforce functions only in certain modes. Id like to next force all the difference modes with types, like the current default internal trigger mode be explicit with .into_trigger(), or elsewhere Ive called this ROM mode. Likewise you could consume that state and do into_pwm() instead.

After that Id like to get a builder pattern going, especially to enforce the complexity of the LRA setup and calibration. maybe something like 
```
let config = drv::Default();
lra.voltage = x;
lra.clamp = y;
lra.drive_time = z;

let mut haptic = Drv::<_, Drv2605Lra>::builder(i2c)
.setup(config) //this will use precalibrated values if they exist, or do a calibrate if they dont.. or you could pass .otp() instead of .setup() which would fail if otp bit wasnt set on chip. 
.connect()?;
let mut haptic = haptic.into_pwm();
```
